### PR TITLE
hostpath: Implement ValidateVolumeCapabilities

### DIFF
--- a/hack/e2e-hostpath.sh
+++ b/hack/e2e-hostpath.sh
@@ -13,9 +13,6 @@ CSI_MOUNTPOINT="/mnt"
 APP=hostpathplugin
 
 SKIP="WithCapacity"
-if [ x${TRAVIS} = x"true" ] ; then
-	SKIP="ValidateVolumeCapabilities"
-fi
 
 # Get csi-sanity
 ./hack/get-sanity.sh


### PR DESCRIPTION
This implements a basic version of ValidateVolumeCapabilities for
hostpath driver and removes this from the skip tests list in the e2e
tests.

Running the e2e tests locally always failed because it was skipped for travisCI environment only.