### PR TITLE
Indicate --kubelet-registration-path through env

### DIFF
--- a/deploy/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/hostpath/csi-hostpath-plugin.yaml
@@ -31,7 +31,7 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: DRIVER_REG_SOCK_DIR
-              value: /opt/rke/var/lib/kubelet/plugins/csi-hostpath
+              value: /var/lib/kubelet/plugins/csi-hostpath
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/deploy/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/hostpath/csi-hostpath-plugin.yaml
@@ -23,13 +23,15 @@ spec:
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_DIR)/csi.sock
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: DRIVER_REG_SOCK_DIR
+              value: /opt/rke/var/lib/kubelet/plugins/csi-hostpath
           volumeMounts:
           - mountPath: /csi
             name: socket-dir


### PR DESCRIPTION
When people operate kubelet with `--root-dir=/foo/bar`, those values
need to be changed. In order to (subtly) indicate externalities of --kubelet-registration-path
feed it through an env variable.