### PR TITLE
Change example deployment scheme in multi-node cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ rolebinding.rbac.authorization.k8s.io/csi-attacher-role-cfg created
 deploying hostpath components
 service/csi-hostpath-attacher created
 statefulset.apps/csi-hostpath-attacher created
-daemonset.apps/csi-hostpathplugin created
+statefulset.apps/csi-hostpathplugin created
 service/csi-hostpath-provisioner created
 statefulset.apps/csi-hostpath-provisioner created
 ```
@@ -50,7 +50,7 @@ $ kubectl get pods
 NAME                         READY   STATUS    RESTARTS   AGE
 csi-hostpath-attacher-0      1/1     Running   0          5m47s
 csi-hostpath-provisioner-0   1/1     Running   0          5m47s
-csi-hostpathplugin-lzzlc     2/2     Running   0          5m45s
+csi-hostpathplugin-0         2/2     Running   0          5m45s
 ```
 
 From the root directory, deploy the application pods including a storage class, a PVC, and a pod which mounts a volume using the Hostpath driver found in directory `./examples`:

--- a/deploy/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/hostpath/csi-hostpath-attacher.yaml
@@ -27,6 +27,16 @@ spec:
       labels:
         app: csi-hostpath-attacher
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher

--- a/deploy/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/hostpath/csi-hostpath-plugin.yaml
@@ -1,8 +1,31 @@
-kind: DaemonSet
+# Service defined here, plus serviceName below in StatefulSet,
+# are needed only because of condition explained in
+# https://github.com/kubernetes/kubernetes/issues/69608
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-hostpathplugin
+  labels:
+    app: csi-hostpathplugin
+spec:
+  selector:
+    app: csi-hostpathplugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpathplugin
 spec:
+  serviceName: "csi-hostpathplugin"
+  # One replica only:
+  # Host path driver only works when everything runs
+  # on a single node. We achieve that by starting it once and then
+  # co-locate all other pods via inter-pod affinity
+  replicas: 1
   selector:
     matchLabels:
       app: csi-hostpathplugin

--- a/deploy/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/hostpath/csi-hostpath-provisioner.yaml
@@ -27,6 +27,16 @@ spec:
       labels:
         app: csi-hostpath-provisioner
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner

--- a/examples/csi-app.yaml
+++ b/examples/csi-app.yaml
@@ -3,6 +3,16 @@ apiVersion: v1
 metadata:
   name: my-csi-app
 spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - csi-hostpathplugin
+        topologyKey: kubernetes.io/hostname
   containers:
     - name: my-frontend
       image: busybox


### PR DESCRIPTION
Current scheme does not work in multi-node cluster because
my-csi-app pod may land on different node than other pods
and mount point is not there.
This commit changes deployment so that there is one
instance of csi-hostpathplugin, and we use inter-pod affinity
to land attacher, provisioner, hostpathplugin and my-csi-appi
on a same node.

Fixes: #12