### PR TITLE
Add snapshot to deploy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,18 @@ clusterrole.rbac.authorization.k8s.io/external-attacher-runner created
 clusterrolebinding.rbac.authorization.k8s.io/csi-attacher-role created
 role.rbac.authorization.k8s.io/external-attacher-cfg created
 rolebinding.rbac.authorization.k8s.io/csi-attacher-role-cfg created
+serviceaccount/csi-snapshotter created
+clusterrole.rbac.authorization.k8s.io/external-snapshotter-runner created
+clusterrolebinding.rbac.authorization.k8s.io/csi-snapshotter-role created
 deploying hostpath components
 service/csi-hostpath-attacher created
 statefulset.apps/csi-hostpath-attacher created
 statefulset.apps/csi-hostpathplugin created
 service/csi-hostpath-provisioner created
 statefulset.apps/csi-hostpath-provisioner created
+deploying snapshotter
+service/csi-hostpath-snapshotter created
+statefulset.apps/csi-hostpath-snapshotter created
 ```
 
 The script can also install CRDs that are needed for alpha features,
@@ -50,6 +56,7 @@ $ kubectl get pods
 NAME                         READY   STATUS    RESTARTS   AGE
 csi-hostpath-attacher-0      1/1     Running   0          5m47s
 csi-hostpath-provisioner-0   1/1     Running   0          5m47s
+csi-hostpath-snapshotter-0   1/1     Running   0          5m47s
 csi-hostpathplugin-0         2/2     Running   0          5m45s
 ```
 

--- a/deploy/deploy-hostpath.sh
+++ b/deploy/deploy-hostpath.sh
@@ -23,6 +23,7 @@ BASE_DIR=$(dirname "$0")
 K8S_RELEASE=${K8S_RELEASE:-"release-1.13"}
 PROVISIONER_RELEASE=${PROVISIONER_RELEASE:-$(image_version "${BASE_DIR}/hostpath/csi-hostpath-provisioner.yaml" csi-provisioner)}
 ATTACHER_RELEASE=${ATTACHER_RELEASE:-$(image_version "${BASE_DIR}/hostpath/csi-hostpath-attacher.yaml" csi-attacher)}
+SNAPSHOTTER_RELEASE=${SNAPSHOTTER_RELEASE:-$(image_version "${BASE_DIR}/snapshotter/csi-hostpath-snpshotter.yaml" csi-snapshotter)}
 INSTALL_CRD=${INSTALL_CRD:-"false"}
 
 # apply CSIDriver and CSINodeInfo API objects
@@ -36,7 +37,12 @@ fi
 echo "applying RBAC rules"
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/${PROVISIONER_RELEASE}/deploy/kubernetes/rbac.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-attacher/${ATTACHER_RELEASE}/deploy/kubernetes/rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_RELEASE}/deploy/kubernetes/rbac.yaml
 
 # deploy hostpath plugin and registrar sidecar
 echo "deploying hostpath components"
 kubectl apply -f ${BASE_DIR}/hostpath
+
+# deploy snapshotter
+echo "deploying snapshotter"
+kubectl apply -f ${BASE_DIR}/snapshotter

--- a/deploy/snapshotter/csi-hostpath-snpshotter.yaml
+++ b/deploy/snapshotter/csi-hostpath-snpshotter.yaml
@@ -27,10 +27,20 @@ spec:
       labels:
         app: csi-hostpath-snapshotter
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
       serviceAccount: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v0.4.1
+          image: quay.io/k8scsi/csi-snapshotter:v1.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--connection-timeout=15s"


### PR DESCRIPTION
Having snapshotter deployed makes the example hostpath deployment
more complete by also showing how to do snapshotting with it.
Snapshotter pod gets similar pod-affinity as were added in previously
made deployment change commit.