### PR TITLE
Make provisioner root persistent across reboot

### DIFF
--- a/deploy/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/hostpath/csi-hostpath-plugin.yaml
@@ -60,6 +60,8 @@ spec:
             name: socket-dir
           - mountPath: /registration
             name: registration-dir
+          - mountPath: /csi-data-dir
+            name: csi-data-dir
 
         - name: hostpath
           image: quay.io/k8scsi/hostpathplugin:v1.0.1
@@ -104,3 +106,8 @@ spec:
             path: /var/lib/kubelet/plugins
             type: Directory
           name: plugins-dir
+            # 'path' is where PV data is persisted on host.
+            # using /tmp is also possible while the PVs will not available after plugin container recreation or host reboot
+            path: /var/lib/csi-hostpath-data/
+            type: DirectoryOrCreate
+          name: csi-data-dir

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -38,8 +38,8 @@ import (
 
 const (
 	deviceID           = "deviceID"
-	provisionRoot      = "/tmp/"
-	snapshotRoot       = "/tmp/"
+	provisionRoot      = "/csi-data-dir"
+	snapshotRoot       = "/csi-data-dir"
 	maxStorageCapacity = tib
 )
 


### PR DESCRIPTION
If the proversioner container or the host restart
data dir under /tmp in the container will be lost thus
causing start up failure for any pods using csi pv.

It's good to make the provisioner root persistent so that
this plugin is  more reliable for daily testing.