### PR TITLE
embed version number

### DIFF
--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -52,7 +52,7 @@ func main() {
 }
 
 func handle() {
-	driver, err := hostpath.NewHostPathDriver(*driverName, *nodeID, *endpoint)
+	driver, err := hostpath.NewHostPathDriver(*driverName, *nodeID, *endpoint, version)
 	if err != nil {
 		fmt.Printf("Failed to initialize driver: %s", err.Error())
 		os.Exit(1)

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -74,7 +74,7 @@ func init() {
 	hostPathVolumeSnapshots = map[string]hostPathSnapshot{}
 }
 
-func NewHostPathDriver(driverName, nodeID, endpoint string) (*hostPath, error) {
+func NewHostPathDriver(driverName, nodeID, endpoint, version string) (*hostPath, error) {
 	if driverName == "" {
 		return nil, fmt.Errorf("No driver name provided")
 	}
@@ -85,6 +85,9 @@ func NewHostPathDriver(driverName, nodeID, endpoint string) (*hostPath, error) {
 
 	if endpoint == "" {
 		return nil, fmt.Errorf("No driver endpoint provided")
+	}
+	if version != "" {
+		vendorVersion = version
 	}
 
 	glog.Infof("Driver: %v ", driverName)


### PR DESCRIPTION
The version number passed by the common release tools goes into
main.version. It has to be passed to the hostpath plugin
implementation.

This broke after v1.0 when introducing the common build rules, i.e. no
releases were affected.