### PR TITLE
deploy: fix PR #20

### DIFF
--- a/deploy/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/hostpath/csi-hostpath-plugin.yaml
@@ -106,6 +106,7 @@ spec:
             path: /var/lib/kubelet/plugins
             type: Directory
           name: plugins-dir
+        - hostPath:
             # 'path' is where PV data is persisted on host.
             # using /tmp is also possible while the PVs will not available after plugin container recreation or host reboot
             path: /var/lib/csi-hostpath-data/


### PR DESCRIPTION
PR #20 introduced broken .yaml, causing a failure from kubectl:
   error: error parsing STDIN: error converting YAML to JSON: yaml: line 91: did not find expected key