### PR TITLE
Added liveness probe to deployment example manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ but as this is something that should be done by the cluster
 provisioning tool it is disabled in the script by default. For this
 and other customizations see the source code of the deploy script.
 
+The [livenessprobe side-container](https://github.com/kubernetes-csi/livenessprobe) provided by the CSI community is deployed with the CSI driver to provide the liveness checking of the CSI services.
+
 ## Run example application and validate
 
 Next, validate the deployment.  First, ensure all expected pods are running properly including the external attacher, provisioner, and the actual hostpath driver plugin:

--- a/deploy/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/hostpath/csi-hostpath-plugin.yaml
@@ -80,6 +80,18 @@ spec:
           imagePullPolicy: Always
           securityContext:
             privileged: true
+          ports:
+          - containerPort: 9898
+            name: healthz
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -89,6 +101,18 @@ spec:
             - mountPath: /var/lib/kubelet/plugins
               mountPropagation: Bidirectional
               name: plugins-dir
+
+        - name: liveness-probe
+          imagePullPolicy: Always
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+          image: quay.io/k8scsi/livenessprobe:v1.0.2
+          args:
+          - --csi-address=/csi/csi.sock
+          - --connection-timeout=3s
+          - --health-port=9898
+
       volumes:
         - hostPath:
             path: /var/lib/kubelet/plugins/csi-hostpath


### PR DESCRIPTION
Liveness probe configuration is added based on deployment
example in kubernetes-csi/livenessprobe.
Different port value is used than default, for showing
how it's configured.