### PR TITLE
node: Add capability check in NodeStageVolume

### DIFF
--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -208,6 +208,9 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if len(req.GetStagingTargetPath()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Target path missing in request")
 	}
+	if req.GetVolumeCapability() == nil {
+		return nil, status.Error(codes.InvalidArgument, "Volume Capability missing in request")
+	}
 
 	return &csi.NodeStageVolumeResponse{}, nil
 }


### PR DESCRIPTION
This fixes the csi-sanity failures for hostpath driver.

```
Node Service
  NodeStageVolume
    should fail when no volume capability is provided [It]

    Expected an error to have occurred.  Got:
        <nil>: nil
```