### PR TITLE
deploy: avoid replacing socat image

### DIFF
--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -164,4 +164,4 @@ done
 
 # deploy snapshotclass
 echo "deploying snapshotclass"
-kubectl create -f ${BASE_DIR}/snapshotter/csi-hostpath-snapshotclass.yaml
+kubectl apply -f ${BASE_DIR}/snapshotter/csi-hostpath-snapshotclass.yaml


### PR DESCRIPTION
Setting IMAGE_TAG or IMAGE_REGISTRY unintentionally also affected the
socat image. This also disables SOCAT_IMAGE_TAG/REGISTRY, but that
should not be needed and wasn't documented either.