### PR TITLE
replace '\s' to [[:space:]] for supporting macos

### DIFF
--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -105,13 +105,13 @@ for i in $(ls ${BASE_DIR}/hostpath/*.yaml | sort); do
     echo "   $i"
     modified="$(cat "$i" | while IFS= read -r line; do
         nocomments="$(echo "$line" | sed -e 's/ *#.*$//')"
-        if echo "$nocomments" | grep -q '^\s*image:\s*'; then
+        if echo "$nocomments" | grep -q '^[[:space:]]*image:[[:space:]]*'; then
             # Split 'image: quay.io/k8scsi/csi-attacher:v1.0.1'
             # into image (quay.io/k8scsi/csi-attacher:v1.0.1),
             # registry (quay.io/k8scsi),
             # name (csi-attacher),
             # tag (v1.0.1).
-            image=$(echo "$nocomments" | sed -e 's;.*image:\s*;;')
+            image=$(echo "$nocomments" | sed -e 's;.*image:[[:space:]]*;;')
             registry=$(echo "$image" | sed -e 's;\(.*\)/.*;\1;')
             name=$(echo "$image" | sed -e 's;.*/\([^:]*\).*;\1;')
             tag=$(echo "$image" | sed -e 's;.*:;;')


### PR DESCRIPTION
I've tried to run the deploy script in MacOS but got following error message:
> error: error parsing STDIN: error converting YAML to JSON: yaml: line 30: could not find expected ':'

It seems the root cause for this error is the `sed` command in MacOS not supports '\s', so the modified yaml file contains invalid image statements like "image:quay.io/k8scsi/csi-attacher:canary"(there should be a space after colon).

The solution was referenced from [here](https://stackoverflow.com/questions/18840175/find-and-replace-with-spaces-using-sed-mac-terminal):
> For POSIX compliance, use the character class [[:space:]] instead of \s, since the latter is a GNU sed extension.
