### PR TITLE
deploy: remove imagePullPolicy for livenessprobe

### DIFF
--- a/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
@@ -101,7 +101,6 @@ spec:
               name: plugins-dir
 
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/deploy/master/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/master/hostpath/csi-hostpath-plugin.yaml
@@ -101,7 +101,6 @@ spec:
               name: plugins-dir
 
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir


### PR DESCRIPTION
Just as for the other containers the image is immutable and therefore
doesn't have to be checked all the time. Required for CI testing,
because it uses an image that is only available locally.
