### PR TITLE
Fixed the Raw Block PV snapshot support

### DIFF
--- a/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
@@ -37,7 +37,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+          image: quay.io/k8scsi/csi-node-driver-registrar:canary
           lifecycle:
             preStop:
               exec:
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.1.0-rc1
+          image: quay.io/k8scsi/hostpathplugin:canary
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
@@ -99,6 +99,8 @@ spec:
             - mountPath: /var/lib/kubelet/plugins
               mountPropagation: Bidirectional
               name: plugins-dir
+            - mountPath: /csi-data-dir
+              name: csi-data-dir
 
         - name: liveness-probe
           volumeMounts:

--- a/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
@@ -37,7 +37,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:canary
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
           lifecycle:
             preStop:
               exec:

--- a/deploy/master/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/master/hostpath/csi-hostpath-plugin.yaml
@@ -99,6 +99,8 @@ spec:
             - mountPath: /var/lib/kubelet/plugins
               mountPropagation: Bidirectional
               name: plugins-dir
+            - mountPath: /csi-data-dir
+              name: csi-data-dir
 
         - name: liveness-probe
           volumeMounts:

--- a/examples/csi-pod-raw.yaml
+++ b/examples/csi-pod-raw.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-raw
+  labels:
+    name: busybox-test
+spec:
+  restartPolicy: Always
+  containers:
+    - image: gcr.io/google_containers/busybox
+      command: ["/bin/sh", "-c"]
+      args: [ "tail -f /dev/null" ]
+      name: busybox
+      volumeDevices:
+        - name: vol
+          devicePath: /dev/loop3 # This device path needs to be replaced with the site specific
+  volumes:
+    - name: vol
+      persistentVolumeClaim:
+        claimName: pvc-raw

--- a/examples/csi-pvc-raw.yaml
+++ b/examples/csi-pvc-raw.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-raw
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: csi-hostpath-sc
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/csi-raw-pv-snapshot.yaml
+++ b/examples/csi-raw-pv-snapshot.yaml
@@ -1,0 +1,9 @@
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshot
+metadata:
+  name: raw-pv-snapshot
+spec:
+  snapshotClassName: csi-hostpath-snapclass
+  source:
+    name: pvc-raw
+    kind: PersistentVolumeClaim

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -38,8 +38,8 @@ import (
 
 const (
 	deviceID           = "deviceID"
-	provisionRoot      = "/csi-data-dir"
-	snapshotRoot       = "/csi-data-dir"
+	provisionRoot      = "/csi-data-dir/"
+	snapshotRoot       = "/csi-data-dir/"
 	maxStorageCapacity = tib
 )
 
@@ -347,7 +347,14 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	creationTime := ptypes.TimestampNow()
 	volPath := hostPathVolume.VolPath
 	file := snapshotRoot + snapshotID + ".tgz"
-	args := []string{"czf", file, "-C", volPath, "."}
+	args := []string{}
+	if hostPathVolume.VolAccessType == blockAccess {
+		glog.V(4).Infof("Creating snapshot of Raw Block Mode Volume")
+		args = []string{"czf", file, volPath}
+	} else {
+		glog.V(4).Infof("Creating snapshot of Filsystem Mode Volume")
+		args = []string{"czf", file, "-C", volPath, "."}
+	}
 	executor := utilexec.New()
 	out, err := executor.Command("tar", args...).CombinedOutput()
 	if err != nil {

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/golang/protobuf/ptypes"
 
@@ -38,8 +39,8 @@ import (
 
 const (
 	deviceID           = "deviceID"
-	provisionRoot      = "/csi-data-dir/"
-	snapshotRoot       = "/csi-data-dir/"
+	provisionRoot      = "/csi-data-dir"
+	snapshotRoot       = "/csi-data-dir"
 	maxStorageCapacity = tib
 )
 
@@ -346,7 +347,8 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	snapshotID := uuid.NewUUID().String()
 	creationTime := ptypes.TimestampNow()
 	volPath := hostPathVolume.VolPath
-	file := snapshotRoot + snapshotID + ".tgz"
+	filePath := []string{snapshotRoot, "/", snapshotID, ".tgz"}
+	file := strings.Join(filePath, "")
 	args := []string{}
 	if hostPathVolume.VolAccessType == blockAccess {
 		glog.V(4).Infof("Creating snapshot of Raw Block Mode Volume")
@@ -396,7 +398,8 @@ func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 	}
 	snapshotID := req.GetSnapshotId()
 	glog.V(4).Infof("deleting volume %s", snapshotID)
-	path := snapshotRoot + snapshotID + ".tgz"
+	pathSlice := []string{snapshotRoot, "/", snapshotID, ".tgz"}
+	path := strings.Join(pathSlice, "")
 	os.RemoveAll(path)
 	delete(hostPathVolumeSnapshots, snapshotID)
 	return &csi.DeleteSnapshotResponse{}, nil


### PR DESCRIPTION
/kind bug


**What this PR does / why we need it**:

Problem:
When Try to create the snapshot of a Raw Block PV, it fails with the following error, if volumesnapshot is described:
```
 Warning  SnapshotCreationFailed  6s    csi-snapshotter csi-hostpath  Failed to create snapshot: failed to take snapshot of the volume, pvc-cb8d96b6-5d40-11e9-bcc0-0236f32917fe: "rpc error: code = Internal desc = failed create snapshot: exit status 1: tar: can't change directory to '/csi-data-dire6fc6eb8-5d40-11e9-97b2-0236f32917fe': Not a directory\n"
```

The issue is described in [https://github.com/kubernetes-csi/csi-driver-host-path/issues/41](url)

Resolution:
1. Corrected the directory format by adding a "/"
2. The "tar" command in case of Block volume should be different. It should consider the vol as a file, which in case of filesystem Mode PV, it is considered as directory
3. The menifests in ./deploy/hostpath is updated, as the hostpathplugin container should be mounted to the "/csi-snapshot-dir" 

**Which issue(s) this PR fixes**:

Fixes #41 


**Does this PR introduce a user-facing change?**:
NONE
