### PR TITLE
deploy: intermediate update to v1.1.0-rc1

### DIFF
--- a/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.0.1
+          image: quay.io/k8scsi/hostpathplugin:v1.1.0-rc1
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

With hostpath driver 1.1.0, we will replace the older v1.0.1 release
for all deployments. This is something that we can start testing in
the CI periodic jobs by updating to the v1.1.0-rc1 image.

**Special notes for your reviewer**:

This makes the deployment on the master branch temporarily use a pre-release image. That is okay according to our policy for these deployments, which is "master might be broken, users should use a tagged release".

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kubernetes 1.13: use hostpath v1.0.0-rc1
```
