### PR TITLE
Implement Cloning for csi-hostpath driver

### DIFF
--- a/examples/csi-clone.yaml
+++ b/examples/csi-clone.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hp-pvc-clone
+spec:
+  storageClassName: csi-hostpath-sc
+  dataSource:
+    name: src-hp-pvc
+    kind: PersistentVolumeClaim
+    apiGroup: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
This PR adds support for cloning of hostpath volumes.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

This PR adds a simple implementation for clone support to the csi-hostpath driver.

**Which issue(s) this PR fixes**:

Fixes #57 

**Special notes for your reviewer**:

Kubernetes changes have merged in to current master, target for Alpha in 1.15
Sidecar changes are here: https://github.com/kubernetes-csi/external-provisioner/pull/220

**Does this PR introduce a user-facing change?**:
<!--
yes
-->
```release-note
Adds support for cloning of hostpath volumes
```
