### PR TITLE
Inline and persistent volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Follow the following example to create a volume from a volume snapshot:
 As of version 1.15 of Kubernetes, the CSI Hostpath driver (starting with version 1.0.1) now includes support for inline ephemeral volume.  This means that a volume can be specified directly inside a pod spec without the need to use a persistent volume object.
 Find out how to enable or create a CSI inline driver [here](https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html)
 
-To test this feature, redeploy the CSI Hostpath plugin YAML by updating the `hostpath` container to use  the inline ephemeral mode by setting the `ephemeral` flag, of the driver binary, to true as shown in the following setup:
+To test this feature on Kubernetes 1.15, redeploy the CSI Hostpath plugin YAML by updating the `hostpath` container to use  the inline ephemeral mode by setting the `ephemeral` flag, of the driver binary, to true as shown in the following setup:
 
 ```yaml
 kind: DaemonSet
@@ -369,6 +369,9 @@ spec:
 
 ```
 Notice the addition of the `ephemeral=true` flag used in the `args:` block in the previous snippet.
+This is an intermediate solution for Kubernetes 1.15. Kubernetes 1.16 will provide [additional
+information to the driver](https://github.com/kubernetes/kubernetes/pull/79983) which makes it
+possible to use the normal deployment for both inline ephemeral volumes and persistent volumes.
 
 Once the driver plugin has been deployed, it can be tested by deploying a simple pod which has an inline volume specified in the spec:
 

--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -48,6 +48,10 @@ func main() {
 		return
 	}
 
+	if *ephemeral {
+		fmt.Fprintln(os.Stderr, "Deprecation warning: The ephemeral flag is deprecated and should only be used when deploying on Kubernetes 1.15. It will be removed in the future.")
+	}
+
 	handle()
 	os.Exit(0)
 }

--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -33,7 +33,7 @@ var (
 	endpoint    = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	driverName  = flag.String("drivername", "hostpath.csi.k8s.io", "name of the driver")
 	nodeID      = flag.String("nodeid", "", "node id")
-	ephemeral   = flag.Bool("ephemeral", false, "deploy in ephemeral mode")
+	ephemeral   = flag.Bool("ephemeral", false, "publish volumes in ephemeral mode even if kubelet did not ask for it (only needed for Kubernetes 1.15)")
 	showVersion = flag.Bool("version", false, "Show version.")
 	// Set by the build process
 	version = ""

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -167,7 +167,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	vol, err := createHostpathVolume(volumeID, req.GetName(), capacity, requestedAccessType)
+	vol, err := createHostpathVolume(volumeID, req.GetName(), capacity, requestedAccessType, false /* ephemeral */)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to create volume: %s", err))
 	}

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -53,6 +53,7 @@ type hostPathVolume struct {
 	VolSize       int64      `json:"volSize"`
 	VolPath       string     `json:"volPath"`
 	VolAccessType accessType `json:"volAccessType"`
+	Ephemeral     bool       `json:"ephemeral"`
 }
 
 type hostPathSnapshot struct {
@@ -148,7 +149,7 @@ func getVolumePath(volID string) string {
 
 // createVolume create the directory for the hostpath volume.
 // It returns the volume path or err if one occurs.
-func createHostpathVolume(volID, name string, cap int64, volAccessType accessType) (*hostPathVolume, error) {
+func createHostpathVolume(volID, name string, cap int64, volAccessType accessType, ephemeral bool) (*hostPathVolume, error) {
 	path := getVolumePath(volID)
 	if volAccessType == mountAccess {
 		err := os.MkdirAll(path, 0777)
@@ -163,6 +164,7 @@ func createHostpathVolume(volID, name string, cap int64, volAccessType accessTyp
 		VolSize:       cap,
 		VolPath:       path,
 		VolAccessType: volAccessType,
+		Ephemeral:     ephemeral,
 	}
 	hostPathVolumes[volID] = hostpathVol
 	return &hostpathVol, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Supporting normal and inline volumes in the same driver deployment makes it possible to test both as part of the existing Prow jobs without having to change the driver deployment.

**Which issue(s) this PR fixes**:
Related-to: https://github.com/kubernetes/kubernetes/issues/79624

**Does this PR introduce a user-facing change?**:
```release-note
The -ephemeral parameter (currently alpha) is still supported, but only needed for Kubernetes 1.15 and will be removed once Kubernetes 1.15 stops being supported. On Kubernetes 1.16, the same deployment supports normal persistent volumes and inline ephemeral volumes.
```
