### PR TITLE
Fix cp arg expansion bug in cloning implementation

### DIFF
--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -293,7 +293,7 @@ func loadFromVolume(srcVolumeId, destPath string) error {
 
 	// If the source hostpath volume is empty it's a noop and we just move along, otherwise the cp call will fail with a a file stat error DNE
 	if !isEmpty {
-		args := []string{"-a", srcPath + "/*", destPath + "/"}
+		args := []string{"-a", srcPath + "/.", destPath + "/"}
 		executor := utilexec.New()
 		out, err := executor.Command("cp", args...).CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

bug


**What this PR does / why we need it**:

The clone implementation is just using `cp /*` can result in trying to actually find/copy a file named `*`.  The result in some container images is a stat error for no such file or directory.  Instead we should be using the cp notation of `/.` so we're portable and always work.

**Which issue(s) this PR fixes**:

Fixes #81

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
