### PR TITLE
[TEST] Create 2-node kind cluster for e2e tests

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -508,6 +508,7 @@ kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 - role: control-plane
+- role: worker
 EOF
 
     # kubeadm has API dependencies between apiVersion and Kubernetes version


### PR DESCRIPTION
**What type of PR is this?**
Test for [the issue](https://github.com/kubernetes-csi/csi-release-tools/issues/28).

cc @msau42 

**What this PR does / why we need it**:
Run hostpath driver e2e tests on 2-node kind cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
