### PR TITLE
Kubernetes 1.16 + ephemeral inline volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,10 @@ Follow the following example to create a volume from a volume snapshot:
 > ```
 
 ## Inline ephemeral support
-As of version 1.15 of Kubernetes, the CSI Hostpath driver (starting with version 1.0.1) now includes support for inline ephemeral volume.  This means that a volume can be specified directly inside a pod spec without the need to use a persistent volume object.
-Find out how to enable or create a CSI inline driver [here](https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html)
+The CSI Hostpath driver (starting with version 1.2.0) now includes support for inline ephemeral volumes. This means that a volume can be specified directly inside a pod spec without the need to use a persistent volume object.
+Find out how to enable or create a CSI driver with support for such volumes [here](https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html)
 
-To test this feature on Kubernetes 1.15, redeploy the CSI Hostpath plugin YAML by updating the `hostpath` container to use  the inline ephemeral mode by setting the `ephemeral` flag, of the driver binary, to true as shown in the following setup:
+To test this feature on Kubernetes 1.15 (and only with that release), redeploy the CSI Hostpath plugin YAML by updating the `hostpath` container to use  the inline ephemeral mode by setting the `ephemeral` flag, of the driver binary, to true as shown in the following setup:
 
 ```yaml
 kind: DaemonSet
@@ -369,9 +369,8 @@ spec:
 
 ```
 Notice the addition of the `ephemeral=true` flag used in the `args:` block in the previous snippet.
-This is an intermediate solution for Kubernetes 1.15. Kubernetes 1.16 will provide [additional
-information to the driver](https://github.com/kubernetes/kubernetes/pull/79983) which makes it
-possible to use the normal deployment for both inline ephemeral volumes and persistent volumes.
+This is an intermediate solution for Kubernetes 1.15. With Kubernetes 1.16 and later, the normal
+deployment supports both inline ephemeral volumes and persistent volumes.
 
 Once the driver plugin has been deployed, it can be tested by deploying a simple pod which has an inline volume specified in the spec:
 

--- a/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc6
+          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc8
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.14/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.14/hostpath/csi-hostpath-plugin.yaml
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc6
+          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc8
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.15/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.15/hostpath/csi-hostpath-plugin.yaml
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc6
+          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc8
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.16/README.md
+++ b/deploy/kubernetes-1.16/README.md
@@ -1,0 +1,3 @@
+The deployment for Kubernetes 1.16 enables ephemeral inline volumes via
+its CSIDriverInfo and thus is incompatible with Kubernetes < 1.16
+because the `VolumeLifecycleModes` field is rejected by those release.

--- a/deploy/kubernetes-1.16/deploy-hostpath.sh
+++ b/deploy/kubernetes-1.16/deploy-hostpath.sh
@@ -1,0 +1,1 @@
+../util/deploy-hostpath.sh

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-attacher.yaml
@@ -1,0 +1,55 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-hostpath-attacher
+  labels:
+    app: csi-hostpath-attacher
+spec:
+  selector:
+    app: csi-hostpath-attacher
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-hostpath-attacher
+spec:
+  serviceName: "csi-hostpath-attacher"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-hostpath-attacher
+  template:
+    metadata:
+      labels:
+        app: csi-hostpath-attacher
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
+      serviceAccountName: csi-attacher
+      containers:
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v1.2.0
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-driverinfo.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-driverinfo.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: hostpath.csi.k8s.io
+spec:
+  # Supports persistent and ephemeral inline volumes.
+  volumeLifecycleModes:
+  - Persistent
+  - Ephemeral
+  # To determine at runtime which mode a volume uses, pod info and its
+  # "csi.storage.k8s.io/ephemeral" entry are needed.
+  podInfoOnMount: true

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
@@ -1,0 +1,138 @@
+# Service defined here, plus serviceName below in StatefulSet,
+# are needed only because of condition explained in
+# https://github.com/kubernetes/kubernetes/issues/69608
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-hostpathplugin
+  labels:
+    app: csi-hostpathplugin
+spec:
+  selector:
+    app: csi-hostpathplugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-hostpathplugin
+spec:
+  serviceName: "csi-hostpathplugin"
+  # One replica only:
+  # Host path driver only works when everything runs
+  # on a single node. We achieve that by starting it once and then
+  # co-locate all other pods via inter-pod affinity
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-hostpathplugin
+  template:
+    metadata:
+      labels:
+        app: csi-hostpathplugin
+    spec:
+      hostNetwork: true
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi-hostpath /registration/csi-hostpath-reg.sock"]
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
+          securityContext:
+            privileged: true
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+          - mountPath: /registration
+            name: registration-dir
+          - mountPath: /csi-data-dir
+            name: csi-data-dir
+
+        - name: hostpath
+          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc6
+          args:
+            - "--drivername=hostpath.csi.k8s.io"
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          ports:
+          - containerPort: 9898
+            name: healthz
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /var/lib/kubelet/plugins
+              mountPropagation: Bidirectional
+              name: plugins-dir
+            - mountPath: /csi-data-dir
+              name: csi-data-dir
+
+        - name: liveness-probe
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          args:
+          - --csi-address=/csi/csi.sock
+          - --connection-timeout=3s
+          - --health-port=9898
+
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins
+            type: Directory
+          name: plugins-dir
+        - hostPath:
+            # 'path' is where PV data is persisted on host.
+            # using /tmp is also possible while the PVs will not available after plugin container recreation or host reboot
+            path: /var/lib/csi-hostpath-data/
+            type: DirectoryOrCreate
+          name: csi-data-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc6
+          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc8
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-provisioner.yaml
@@ -1,0 +1,56 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-hostpath-provisioner 
+  labels:
+    app: csi-hostpath-provisioner 
+spec:
+  selector:
+    app: csi-hostpath-provisioner 
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-hostpath-provisioner
+spec:
+  serviceName: "csi-hostpath-provisioner"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-hostpath-provisioner
+  template:
+    metadata:
+      labels:
+        app: csi-hostpath-provisioner
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
+      serviceAccountName: csi-provisioner
+      containers:
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.3.0
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+            - --connection-timeout=15s
+            - --feature-gates=Topology=true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-resizer.yaml
@@ -1,0 +1,54 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-hostpath-resizer
+  labels:
+    app: csi-hostpath-resizer
+spec:
+  selector:
+    app: csi-hostpath-resizer
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-hostpath-resizer
+spec:
+  serviceName: "csi-hostpath-resizer"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-hostpath-resizer
+  template:
+    metadata:
+      labels:
+        app: csi-hostpath-resizer
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
+      serviceAccountName: csi-resizer
+      containers:
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          args:
+            - -v=5
+            - -csi-address=/csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-snapshotter.yaml
@@ -1,0 +1,55 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-hostpath-snapshotter
+  labels:
+    app: csi-hostpath-snapshotter
+spec:
+  selector:
+    app: csi-hostpath-snapshotter
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-hostpath-snapshotter
+spec:
+  serviceName: "csi-hostpath-snapshotter"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-hostpath-snapshotter
+  template:
+    metadata:
+      labels:
+        app: csi-hostpath-snapshotter
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
+      serviceAccount: csi-snapshotter
+      containers:
+        - name: csi-snapshotter
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.0
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+            - --connection-timeout=15s
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-testing.yaml
@@ -1,0 +1,59 @@
+# WARNING: this is only for testing purposes. Do not install in a production
+# cluster.
+#
+# This exposes the hostpath's Unix domain csi.sock as a TCP port to the
+# outside world. The mapping from Unix domain socket to TCP is done
+# by socat.
+#
+# This is useful for testing with csi-sanity or csc.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: hostpath-service
+spec:
+  type: NodePort
+  selector:
+    app: csi-hostpath-socat
+  ports:
+  - port: 10000 # fixed port inside the pod, dynamically allocated port outside
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-hostpath-socat
+spec:
+  serviceName: "csi-hostpath-socat"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-hostpath-socat
+  template:
+    metadata:
+      labels:
+        app: csi-hostpath-socat
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
+      containers:
+        - name: socat
+          image: alpine/socat:1.0.3
+          args:
+            - tcp-listen:10000,fork,reuseaddr
+            - unix-connect:/csi/csi.sock
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir

--- a/deploy/kubernetes-1.16/snapshotter/csi-hostpath-snapshotclass.yaml
+++ b/deploy/kubernetes-1.16/snapshotter/csi-hostpath-snapshotclass.yaml
@@ -1,0 +1,5 @@
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-hostpath-snapclass
+snapshotter: hostpath.csi.k8s.io

--- a/deploy/kubernetes-latest
+++ b/deploy/kubernetes-latest
@@ -1,1 +1,1 @@
-kubernetes-1.15
+kubernetes-1.16


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

For Kubernetes 1.16 a new deployment is needed with a new
csi-hostpath-driverinfo.yaml file that enables "ephemeral"
volumes. The only difference compared to the kubernetes-1.15
deployment is that file and the updated README.md.

With that deployment and Kubernetes >= 1.16, using inline volumes no
longer depends on modifying the deployment.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
ephemeral inline volumes in addition to normal volumes on Kubernetes 1.16
```
