### PR TITLE
WIP: Remove snapshot class creation in deploy script

### DIFF
--- a/deploy/kubernetes-1.14/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.14/hostpath/csi-hostpath-plugin.yaml
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.2.0
+          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc8
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.15/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.15/hostpath/csi-hostpath-plugin.yaml
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.2.0
+          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc8
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
@@ -63,7 +63,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.2.0
+          image: quay.io/k8scsi/hostpathplugin:v1.2.0-rc8
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
* csi-snapshotter uses the hostpath deploy script for e2e tests. It's failing in https://github.com/kubernetes-csi/external-snapshotter/pull/139 due to the snapshot class creation.

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
