### PR TITLE
Fix #107: document kubelet default --root-dir assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ This repository hosts the CSI Hostpath driver and all of its build and dependent
 
 ## Pre-requisite
 - Kubernetes cluster
-- Running version 1.13 or later
+- Running version 1.14 or later
 - Access to terminal with `kubectl` installed
 
 ## Deployment
 The easiest way to test the Hostpath driver is to run the `deploy-hostpath.sh` script for the Kubernetes version used by
-the cluster as shown below for Kubernetes 1.13. This creates the deployment that is maintained specifically for that
+the cluster as shown below for Kubernetes 1.16. This creates the deployment that is maintained specifically for that
 release of Kubernetes. However, other deployments may also work. For details see the individual READMEs.
 
+Note: the following assumes that kubelet runs with the default root dir of `/var/lib/kubelet`. If kubelet in your cluster runs with the `--root-dir` option pointing to a different directory then the .yaml files in `deploy/kubernetes-<version>/hostpath/` will need to be modified appropriately.
+
 ```shell
-$ deploy/kubernetes-1.13/deploy-hostpath.sh
+$ deploy/kubernetes-1.16/deploy-hostpath.sh
 ```
 
 You should see an output similar to the following printed on the terminal showing the application of rbac rules and the result of deploying the hostpath driver, external provisioner, external attacher and snapshotter components:
@@ -37,25 +39,25 @@ serviceaccount/csi-snapshotter created
 clusterrole.rbac.authorization.k8s.io/external-snapshotter-runner created
 clusterrolebinding.rbac.authorization.k8s.io/csi-snapshotter-role created
 deploying hostpath components
-   deploy/kubernetes-1.13/hostpath/csi-hostpath-attacher.yaml
+   deploy/kubernetes-1.16/hostpath/csi-hostpath-attacher.yaml
         using           image: quay.io/k8scsi/csi-attacher:v1.0.1
 service/csi-hostpath-attacher created
 statefulset.apps/csi-hostpath-attacher created
-   deploy/kubernetes-1.13/hostpath/csi-hostpath-plugin.yaml
+   deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
         using           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
         using           image: quay.io/k8scsi/hostpathplugin:v1.0.1
         using           image: quay.io/k8scsi/livenessprobe:v1.0.2
 service/csi-hostpathplugin created
 statefulset.apps/csi-hostpathplugin created
-   deploy/kubernetes-1.13/hostpath/csi-hostpath-provisioner.yaml
+   deploy/kubernetes-1.16/hostpath/csi-hostpath-provisioner.yaml
         using           image: quay.io/k8scsi/csi-provisioner:v1.0.1
 service/csi-hostpath-provisioner created
 statefulset.apps/csi-hostpath-provisioner created
-   deploy/kubernetes-1.13/hostpath/csi-hostpath-snapshotter.yaml
+   deploy/kubernetes-1.16/hostpath/csi-hostpath-snapshotter.yaml
         using           image: quay.io/k8scsi/csi-snapshotter:v1.0.1
 service/csi-hostpath-snapshotter created
 statefulset.apps/csi-hostpath-snapshotter created
-   deploy/kubernetes-1.13/hostpath/csi-hostpath-testing.yaml
+   deploy/kubernetes-1.16/hostpath/csi-hostpath-testing.yaml
         using           image: alpine/socat:1.0.3
 service/hostpath-service created
 statefulset.apps/csi-hostpath-socat created


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
README.md: note how to avoid mysterious problem of CSINode objects
not appearing on driver installation.
Also update Kubernetes version numbers to reflect those supported.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #107

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Document kubelet root dir assumption.
```
