### PR TITLE
deployment: blacklist updating attacher in 1.14 to canary

### DIFF
--- a/deploy/kubernetes-1.14/canary-blacklist.txt
+++ b/deploy/kubernetes-1.14/canary-blacklist.txt
@@ -1,3 +1,4 @@
 # The following canary images are known to be incompatible with this
 # deployment:
+csi-attacher
 csi-snapshotter


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

The new v2.0.0 of the external-attacher that is used with 1.15 and
1.16 is not compatible with the 1.14 deployment (RBAC change) and thus
the canary test job for 1.14 must not use the canary version of the
external-attacher.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
