### PR TITLE
system pod logging

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -683,16 +683,16 @@ EOF
 
 }
 
-# Gets logs of all containers in the default namespace. When passed -f, kubectl will
+# Gets logs of all containers in all namespaces. When passed -f, kubectl will
 # keep running and capture new output. Prints the pid of all background processes.
 # The caller must kill (when using -f) and/or wait for them.
 #
 # May be called multiple times and thus appends.
 start_loggers () {
-    kubectl get pods -o go-template --template='{{range .items}}{{.metadata.name}} {{range .spec.containers}}{{.name}} {{end}}{{"\n"}}{{end}}' | while read -r pod containers; do
+    kubectl get pods --all-namespaces -o go-template --template='{{range .items}}{{.metadata.namespace}} {{.metadata.name}} {{range .spec.containers}}{{.name}} {{end}}{{"\n"}}{{end}}' | while read -r namespace pod containers; do
         for container in $containers; do
-            mkdir -p "${ARTIFACTS}/$pod"
-            kubectl logs "$@" "$pod" "$container" >>"${ARTIFACTS}/$pod/$container.log" &
+            mkdir -p "${ARTIFACTS}/$namespace/$pod"
+            kubectl logs -n "$namespace" "$@" "$pod" "$container" >>"${ARTIFACTS}/$namespace/$pod/$container.log" &
             echo "$!"
         done
     done


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

This imports the updated csi-release-tools with logging of system containers, which will be useful for the periodic Prow jobs (now) and pull request testing (after doing a release and bumping up the version of csi-driver-host-path that is used in those jobs).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
