### PR TITLE
Run all containers as privileged

### DIFF
--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-attacher.yaml
@@ -44,6 +44,11 @@ spec:
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
@@ -46,6 +46,9 @@ spec:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
           securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
             privileged: true
           env:
             - name: KUBE_NODE_NAME
@@ -107,6 +110,11 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:
           - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
@@ -34,7 +34,6 @@ spec:
       labels:
         app: csi-hostpathplugin
     spec:
-      hostNetwork: true
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-provisioner.yaml
@@ -46,6 +46,11 @@ spec:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=15s
             - --feature-gates=Topology=true
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-resizer.yaml
@@ -44,6 +44,11 @@ spec:
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-snapshotter.yaml
@@ -45,6 +45,11 @@ spec:
             - -v=5
             - --csi-address=/csi/csi.sock
             - --connection-timeout=15s
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-testing.yaml
@@ -49,6 +49,11 @@ spec:
           args:
             - tcp-listen:10000,fork,reuseaddr
             - unix-connect:/csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           volumeMounts:
           - mountPath: /csi
             name: socket-dir


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
(All hostpath tests are broken on RHEL / CentOS with SELinux)

**What this PR does / why we need it**:
On systems with SELinux enabled, non-privileged containers can't access data of privileged containers. Since the socket is exposed by privileged container, all sidecars must be privileged too.

And I removed `hostNetwork: true`  while at it - was it used for anything? It exposes liveness probe port on the host and therefore one node can run only one driver, limiting parallelization of the tests.

@pohly @msau42, PTAL. I know it might be controversial, but it's necessary for RHEL / CentOS.

```release-note
NONE
```
