### PR TITLE
Fix errors in deploy script

### DIFF
--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -102,9 +102,9 @@ function rbac_version () {
 # version_gt 1.1.1 release-1.2.0  (returns false)
 # version_gt 1.2.0 1.2.2  (returns false)
 function version_gt() { 
-    versions=$(for ver in "$@"; do ver=${ver#release-}; echo ${ver#v}; done)
+    versions=$(for ver in "$@"; do ver=${ver#release-}; ver=${ver#kubernetes-}; echo ${ver#v}; done)
     greaterVersion=${1#"release-"};  
-    greaterVersion=${1#"kubernetes-"};  
+    greaterVersion=${greaterVersion#"kubernetes-"};
     greaterVersion=${greaterVersion#"v"}; 
     test "$(printf '%s' "$versions" | sort -V | head -n 1)" != "$greaterVersion"
 }
@@ -221,7 +221,7 @@ done
 # deploy snapshotclass
 echo "deploying snapshotclass based on snapshotter version"
 snapshotter_version="$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-snapshotter.yaml" csi-snapshotter false)"
-driver_version="$(basename $PWD)"
+driver_version="$(basename "${BASE_DIR}")"
 if version_gt "$driver_version" "1.16"; then
     kubectl apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${snapshotter_version}/examples/kubernetes/snapshotclass.yaml" 
 fi

--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -222,6 +222,6 @@ done
 echo "deploying snapshotclass based on snapshotter version"
 snapshotter_version="$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-snapshotter.yaml" csi-snapshotter false)"
 driver_version="$(basename $PWD)"
-if [ version_gt $driver_version "1.16" ]; then
+if version_gt "$driver_version" "1.16"; then
     kubectl apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${snapshotter_version}/examples/kubernetes/snapshotclass.yaml" 
 fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When using the deploy script, it generated the following error:
```
./deploy/kubernetes-1.17/deploy-hostpath.sh: line 225: [: csi-driver-host-path: binary operator expected
```

`version_gt` was also being passed an incorrect value, and the function itself was not properly stripping the `kubernetes-` prefix from the passed values.

Previously, the `snapshotclass.yaml` was never being deployed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
