### PR TITLE
Add check for  volumecontent source in CreateVolume

### DIFF
--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -60,6 +60,8 @@ type hostPathVolume struct {
 	VolSize       int64      `json:"volSize"`
 	VolPath       string     `json:"volPath"`
 	VolAccessType accessType `json:"volAccessType"`
+	ParentVolID   string     `json:"parentVolID,omitempty"`
+	ParentSnapID  string     `json:"parentSnapID,omitempty"`
 	Ephemeral     bool       `json:"ephemeral"`
 }
 

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hostpath
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -93,15 +94,15 @@ func init() {
 
 func NewHostPathDriver(driverName, nodeID, endpoint string, ephemeral bool, maxVolumesPerNode int64, version string) (*hostPath, error) {
 	if driverName == "" {
-		return nil, fmt.Errorf("No driver name provided")
+		return nil, errors.New("no driver name provided")
 	}
 
 	if nodeID == "" {
-		return nil, fmt.Errorf("No node id provided")
+		return nil, errors.New("no node id provided")
 	}
 
 	if endpoint == "" {
-		return nil, fmt.Errorf("No driver endpoint provided")
+		return nil, errors.New("no driver endpoint provided")
 	}
 	if version != "" {
 		vendorVersion = version


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
If the volume is already found during create volume request,we also need to check the volume content source id valid or not.
If the returning error message doesn't require formatting, use errors.New().

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
