### PR TITLE
Add support to all k8s versions for VolumeSnapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,11 +237,16 @@ Since volume snapshot is an alpha feature starting in Kubernetes v1.12, you need
 After having created the `csi-pvc` as described in the example above,
 use the volume snapshot class to dynamically create a volume snapshot:
 
-> $ kubectl apply -f examples/csi-snapshot.yaml
+> For Kubernetes < v1.17 
+>
+>  - `$ kubectl apply -f examples/csi-snapshot.yaml`
+>
+> For Kubernetes >= v1.17
+>  - `$ kubectl apply -f examples/csi-snapshot-v1beta1.yaml`
 > ```
 > volumesnapshot.snapshot.storage.k8s.io/new-snapshot-demo created
 > ```
->
+
 >
 > $ kubectl get volumesnapshot
 > ```

--- a/examples/csi-snapshot-v1beta1.yaml
+++ b/examples/csi-snapshot-v1beta1.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: new-snapshot-demo
+spec:
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  source:
+    persistentVolumeClaimName: csi-pvc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Have added a new file `csi-snapshot-v1beta1.yaml` which creates VolumeSnapshot object (for apiversion v1beta1) which can be applied for k8s version >=v1.17

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #159 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
