### PR TITLE
Discover existing snapshots on disk

### DIFF
--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -281,8 +281,8 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 }
 
 // getSnapshotPath returns the full path to where the snapshot is stored
-func getSnapshotPath(snapshotId string) string {
-	return filepath.Join(dataRoot, fmt.Sprintf("%s.snap", snapshotId))
+func getSnapshotPath(snapshotID string) string {
+	return filepath.Join(dataRoot, fmt.Sprintf("%s%s", snapshotID, snapshotExt))
 }
 
 // CreateSnapshot uses tar command to create snapshot for hostpath volume. The tar command can quickly create

--- a/pkg/hostpath/hostpath_test.go
+++ b/pkg/hostpath/hostpath_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostpath
+
+import (
+	"testing"
+)
+
+func TestGetSnapshotID(t *testing.T) {
+	testCases := []struct {
+		name               string
+		inputPath          string
+		expectedIsSnapshot bool
+		expectedSnapshotID string
+	}{
+		{
+			name:               "should recognize foo.snap as a valid snapshot with ID foo",
+			inputPath:          "foo.snap",
+			expectedIsSnapshot: true,
+			expectedSnapshotID: "foo",
+		},
+		{
+			name:               "should recognize baz.tar.gz as an invalid snapshot",
+			inputPath:          "baz.tar.gz",
+			expectedIsSnapshot: false,
+			expectedSnapshotID: "",
+		},
+		{
+			name:               "should recognize baz.tar.snap as a valid snapshot with ID baz.tar",
+			inputPath:          "baz.tar.snap",
+			expectedIsSnapshot: true,
+			expectedSnapshotID: "baz.tar",
+		},
+		{
+			name:               "should recognize baz.tar.snap.snap as a valid snapshot with ID baz.tar.snap",
+			inputPath:          "baz.tar.snap.snap",
+			expectedIsSnapshot: true,
+			expectedSnapshotID: "baz.tar.snap",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualIsSnapshot, actualSnapshotID := getSnapshotID(tc.inputPath)
+			if actualIsSnapshot != tc.expectedIsSnapshot {
+				t.Errorf("unexpected result for path %s, Want: %t, Got: %t", tc.inputPath, tc.expectedIsSnapshot, actualIsSnapshot)
+			}
+			if actualSnapshotID != tc.expectedSnapshotID {
+				t.Errorf("unexpected snapshotID for path %s, Want: %s; Got :%s", tc.inputPath, tc.expectedSnapshotID, actualSnapshotID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This change lets this driver discover existing snapshots on disk and therefore improves testability of the scenario of "Importing an existing volume snapshot with Kubernetes"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds ability to discover and import existing on-disk tarballs as snapshots.
```
