### PR TITLE
Remove snapshot e2e testing from alpha versions.

### DIFF
--- a/deploy/kubernetes-1.15/test-driver.yaml
+++ b/deploy/kubernetes-1.15/test-driver.yaml
@@ -4,8 +4,6 @@
 
 StorageClass:
   FromName: true
-SnapshotClass:
-  FromName: true
 DriverInfo:
   Name: hostpath.csi.k8s.io
   Capabilities:

--- a/deploy/kubernetes-1.16/test-driver.yaml
+++ b/deploy/kubernetes-1.16/test-driver.yaml
@@ -4,8 +4,6 @@
 
 StorageClass:
   FromName: true
-SnapshotClass:
-  FromName: true
 DriverInfo:
   Name: hostpath.csi.k8s.io
   Capabilities:
@@ -15,4 +13,3 @@ DriverInfo:
     multipods: true
     nodeExpansion: true
     persistence: true
-    snapshotDataSource: true


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
//kind failing-test

**What this PR does / why we need it**:
Disables snapshot e2es for 1.16 deployment.

prow.sh uses the e2e version that matches the k8s version. Skew testing
(driver version != k8s version) doesn't work for alpha features.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
