### PR TITLE
add nodeAffinity rule to inline volume example

### DIFF
--- a/examples/csi-app-inline.yaml
+++ b/examples/csi-app-inline.yaml
@@ -3,6 +3,13 @@ apiVersion: v1
 metadata:
   name: my-csi-app-inline
 spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.hostpath.csi/node
+            operator: Exists
   containers:
     - name: my-frontend
       image: busybox


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

In a 1.17 multi-worker-node environment, with hostpath driver running on a single node properly registered/labeled, I needed to set this `nodeAffinity` rule to get this example to work. Without it, pod can potentially land on an unregistered node:

```MountVolume.SetUp failed for volume "my-csi-volume" : kubernetes.io/csi: mounter.SetUpAt failed to get CSI client: driver name hostpath.csi.k8s.io not found in the list of registered CSI drivers```

I believe this is being addressed here: https://github.com/kubernetes/enhancements/pull/1353


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```