### PR TITLE
Fix deploy-hostpath.sh hostpath pod and CRD conditional for k8s 1.16

### DIFF
--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -203,11 +203,10 @@ done
 # snapshotter, resizer, socat and hostpath plugin in the default namespace.
 expected_running_pods=6
 cnt=0
-while [ $(kubectl get pods 2>/dev/null | grep '^csi-hostpath.* Running ' | wc -l) -lt $expected_running_pods ] || ! kubectl describe volumesnapshotclasses.snapshot.storage.k8s.io 2>/dev/null >/dev/null; do
+while [ $(kubectl get pods 2>/dev/null | grep '^csi-hostpath.* Running ' | wc -l) -lt ${expected_running_pods} ]; do
     if [ $cnt -gt 30 ]; then
         echo "$(kubectl get pods 2>/dev/null | grep '^csi-hostpath.* Running ' | wc -l) running pods:"
         kubectl describe pods
-        (set -x; kubectl describe volumesnapshotclasses.snapshot.storage.k8s.io) || true
 
         echo >&2 "ERROR: hostpath deployment not ready after over 5min"
         exit 1


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In https://github.com/kubernetes-csi/external-snapshotter/pull/299,
deploy-hostpath is hanging due to an invalid conditional.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
