### PR TITLE
Remove preStop hook

### DIFF
--- a/deploy/kubernetes-1.15/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.15/hostpath/csi-hostpath-plugin.yaml
@@ -38,10 +38,6 @@ spec:
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-hostpath /registration/csi-hostpath-reg.sock"]
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-plugin.yaml
@@ -37,10 +37,6 @@ spec:
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-hostpath /registration/csi-hostpath-reg.sock"]
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.17/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.17/hostpath/csi-hostpath-plugin.yaml
@@ -37,10 +37,6 @@ spec:
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-hostpath /registration/csi-hostpath-reg.sock"]
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
@@ -37,10 +37,6 @@ spec:
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-hostpath /registration/csi-hostpath-reg.sock"]
           args:
             - --v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
node-driver-registar image is distrolles and does not have /bin/sh. The hook always fails.

/kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #175

See also https://github.com/kubernetes-csi/node-driver-registrar/issues/21

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Removed useless preStop hooks from the driver pod.
```
