### PR TITLE
cloud build: initialize support for running commands in Dockerfile

### DIFF
--- a/.cloudbuild.sh
+++ b/.cloudbuild.sh
@@ -1,1 +1,11 @@
-release-tools/cloudbuild.sh
+#! /bin/bash
+
+# shellcheck disable=SC1091
+. release-tools/prow.sh
+
+if find . -name Dockerfile | grep -v ^./vendor | xargs --no-run-if-empty cat | grep -q ^RUN; then
+    # Needed for "RUN apk" on non linux/amd64 platforms.
+    (set -x; docker run --rm --privileged multiarch/qemu-user-static --reset -p yes)
+fi
+
+gcr_cloud_build


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The Dockerfile needs to run apk, which fails during the cloud build
with:
  failed to solve: rpc error: code = Unknown desc = failed to load
  LLB: runtime execution on platform linux/ppc64le not supported

The fix is described in https://github.com/multiarch/qemu-user-static#getting-started

**Which issue(s) this PR fixes**:
Related-to: https://github.com/kubernetes-csi/csi-release-tools/issues/86

**Special notes for your reviewer**:

If this works, the `if` check will be moved into `csi-release-tools/prow.sh` and then become available also to other repos which need it (like some of the other CSI drivers).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @jsafrane 