### PR TITLE
master: update release-tools

### DIFF
--- a/.cloudbuild.sh
+++ b/.cloudbuild.sh
@@ -1,11 +1,1 @@
-#! /bin/bash
-
-# shellcheck disable=SC1091
-. release-tools/prow.sh
-
-if find . -name Dockerfile | grep -v ^./vendor | xargs --no-run-if-empty cat | grep -q ^RUN; then
-    # Needed for "RUN apk" on non linux/amd64 platforms.
-    (set -x; docker run --rm --privileged multiarch/qemu-user-static --reset -p yes)
-fi
-
-gcr_cloud_build
+release-tools/cloudbuild.sh

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -1198,6 +1198,12 @@ gcr_cloud_build () {
     # Required for "docker buildx build --push".
     gcloud auth configure-docker
 
+    if find . -name Dockerfile | grep -v ^./vendor | xargs --no-run-if-empty cat | grep -q ^RUN; then
+        # Needed for "RUN" steps on non-linux/amd64 platforms.
+        # See https://github.com/multiarch/qemu-user-static#getting-started
+        (set -x; docker run --rm --privileged multiarch/qemu-user-static --reset -p yes)
+    fi
+
     # Extract tag-n-hash value from GIT_TAG (form vYYYYMMDD-tag-n-hash) for REV value.
     REV=v$(echo "$GIT_TAG" | cut -f3- -d 'v')
 


### PR DESCRIPTION
This replaces the previous, hostpath-specific code from https://github.com/kubernetes-csi/csi-driver-host-path/pull/182 with the same code from csi-release-tools.

Commit summary:
db0c2a7d cloud build: initialize support for running commands in Dockerfile

```release-note
NONE
```