### PR TITLE
Do not use latest version of image against older version of rbac rules

### DIFF
--- a/deploy/kubernetes-1.16/canary-blacklist.txt
+++ b/deploy/kubernetes-1.16/canary-blacklist.txt
@@ -3,3 +3,4 @@
 csi-snapshotter
 csi-attacher
 csi-provisioner
+csi-resizer


### PR DESCRIPTION
Using canary image with older version of rbac rules do not work for resizer.

The job in question - https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml#L814 

I do not see how this can be made to work either without black listing csi-resizer here or by setting `UPDATE_RBAC_RULES` to `true` in linked job.

/assign @pohly @msau42 