### PR TITLE
Update provisioner version to fix canary jobs

### DIFF
--- a/deploy/kubernetes-1.17/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.17/hostpath/csi-hostpath-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.5.0
+          image: gcr.io/k8s-staging-sig-storage/csi-provisioner:v2.0.0-rc2
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: gcr.io/k8s-staging-sig-storage/csi-provisioner:v2.0.0-rc2
           args:
             - -v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
https://github.com/kubernetes-csi/external-provisioner/pull/438 added new rbacs on volumeattachment. Update to temporary pre-release image to make canary jobs pass.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
