### PR TITLE
Remove services from Sidecar yaml

### DIFF
--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-attacher.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-attacher
-  labels:
-    app: csi-hostpath-attacher
-spec:
-  selector:
-    app: csi-hostpath-attacher
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-provisioner.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-provisioner 
-  labels:
-    app: csi-hostpath-provisioner 
-spec:
-  selector:
-    app: csi-hostpath-provisioner 
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-resizer.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-resizer
-  labels:
-    app: csi-hostpath-resizer
-spec:
-  selector:
-    app: csi-hostpath-resizer
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.16/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.16/hostpath/csi-hostpath-snapshotter.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-snapshotter
-  labels:
-    app: csi-hostpath-snapshotter
-spec:
-  selector:
-    app: csi-hostpath-snapshotter
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.17/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.17/hostpath/csi-hostpath-attacher.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-attacher
-  labels:
-    app: csi-hostpath-attacher
-spec:
-  selector:
-    app: csi-hostpath-attacher
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.17/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.17/hostpath/csi-hostpath-provisioner.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-provisioner 
-  labels:
-    app: csi-hostpath-provisioner 
-spec:
-  selector:
-    app: csi-hostpath-provisioner 
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.17/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.17/hostpath/csi-hostpath-resizer.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-resizer
-  labels:
-    app: csi-hostpath-resizer
-spec:
-  selector:
-    app: csi-hostpath-resizer
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.17/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.17/hostpath/csi-hostpath-snapshotter.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-snapshotter
-  labels:
-    app: csi-hostpath-snapshotter
-spec:
-  selector:
-    app: csi-hostpath-snapshotter
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-attacher.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-attacher
-  labels:
-    app: csi-hostpath-attacher
-spec:
-  selector:
-    app: csi-hostpath-attacher
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-provisioner 
-  labels:
-    app: csi-hostpath-provisioner 
-spec:
-  selector:
-    app: csi-hostpath-provisioner 
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-resizer.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-resizer
-  labels:
-    app: csi-hostpath-resizer
-spec:
-  selector:
-    app: csi-hostpath-resizer
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-snapshotter.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-hostpath-snapshotter
-  labels:
-    app: csi-hostpath-snapshotter
-spec:
-  selector:
-    app: csi-hostpath-snapshotter
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

Removing Service Spec from sidecar yaml (csi-hostpath-attacher.yaml,csi-hostpath-provisioner.yaml,csi-hostpath-snapshotter.yaml,csi-hostpath-resizer.yaml ) for Kubernetes-1.16,Kubernetes-1.17,Kubernetes-1.18

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #170 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
NONE
```
