### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -39,10 +39,11 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Changes can then be updated in all the sidecar repos and hostpath driver repo
    by following the [update
    instructions](https://github.com/kubernetes-csi/csi-release-tools/blob/master/README.md#sharing-and-updating).
-1. New pull and CI jobs are configured by
+1. New pull and CI jobs are configured by adding new K8s versions to the top of
    [gen-jobs.sh](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-csi/gen-jobs.sh).
-   New pull jobs that have been unverified should be initially made optional.
-   [Example](https://github.com/kubernetes/test-infra/pull/15055)
+   New pull jobs that have been unverified should be initially made optional by
+   setting the new K8s version as
+   [experimental](https://github.com/kubernetes/test-infra/blob/a1858f46d6014480b130789df58b230a49203a64/config/jobs/kubernetes-csi/gen-jobs.sh#L40).
 1. Once new pull and CI jobs have been verified, and the new Kubernetes version
    is released, we can make the optional jobs required, and also remove the
    Kubernetes versions that are no longer supported.
@@ -54,14 +55,19 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
   generator](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
 1. Generate release notes for the release. Replace arguments with the relevant
   information.
+    * Clean up old cached information (also needed if you are generating release
+      notes for multiple repos)
+      ```bash
+      rm -rf /tmp/k8s-repo
+      ```
     * For new minor releases on master:
-        ```
+        ```bash
         GITHUB_TOKEN=<token> release-notes --discover=mergebase-to-latest
         --github-org=kubernetes-csi --github-repo=external-provisioner
         --required-author="" --output out.md
         ```
     * For new patch releases on a release branch:
-        ```
+        ```bash
         GITHUB_TOKEN=<token> release-notes --discover=patch-to-latest --branch=release-1.1
         --github-org=kubernetes-csi --github-repo=external-provisioner
         --required-author="" --output out.md

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -212,7 +212,7 @@ configvar CSI_PROW_DRIVER_INSTALL "install_csi_driver" "name of the shell functi
 configvar CSI_PROW_DRIVER_CANARY "${CSI_PROW_HOSTPATH_CANARY}" "driver image override for canary images"
 
 # Image registry to use for canary images.
-# Only valid if CSI_PROW_DRIVER_CANARY is set.
+# Only valid if CSI_PROW_DRIVER_CANARY == "canary".
 configvar CSI_PROW_DRIVER_CANARY_REGISTRY "gcr.io/k8s-staging-sig-storage" "registry for canary images"
 
 # The E2E testing can come from an arbitrary repo. The expectation is that
@@ -697,7 +697,11 @@ install_csi_driver () {
     fi
 
     if [ "${CSI_PROW_DRIVER_CANARY}" != "stable" ]; then
+      if [ "${CSI_PROW_DRIVER_CANARY}" == "canary" ]; then
         images="$images IMAGE_TAG=${CSI_PROW_DRIVER_CANARY} IMAGE_REGISTRY=${CSI_PROW_DRIVER_CANARY_REGISTRY}"
+      else
+        images="$images IMAGE_TAG=${CSI_PROW_DRIVER_CANARY}"
+      fi
     fi
     # Ignore: Double quote to prevent globbing and word splitting.
     # It's intentional here for $images.


### PR DESCRIPTION
Replace "release-tools" with a squashed commit.

Squashed 'release-tools/' changes from 3041b8a4..a0f195cc

a0f195cc Merge pull request #106 from msau42/fix-canary
7100c120 Only set staging registry when running canary job
b3c65f9c Merge pull request #99 from msau42/add-release-process
e53f3e85 Merge pull request #103 from msau42/fix-canary
d1294628 Document new method for adding CI jobs are new K8s versions
e73c2ce5 Use staging registry for canary tests
2c098465 Add cleanup instructions to release-notes generation
60e1cd3d Merge pull request #98 from pohly/kubernetes-1-19-fixes
0979c091 prow.sh: fix E2E suite for Kubernetes >= 1.18
3b4a2f1d prow.sh: fix installing Go for Kubernetes 1.19.0
1fbb636c Merge pull request #97 from pohly/go-1.15
82d108ac switch to Go 1.15
d8a25300 Merge pull request #95 from msau42/add-release-process
843bddca Add steps on promoting release images
0345a835 Merge pull request #94 from linux-on-ibm-z/bump-timeout
1fdf2d53 cloud build: bump timeout in Prow job
41ec6d15 Merge pull request #93 from animeshk08/patch-1
5a54e67d filter-junit: Fix gofmt error
0676fcbd Merge pull request #92 from animeshk08/patch-1
36ea4ffa filter-junit: Fix golint error
f5a42037 Merge pull request #91 from cyb70289/arm64
43e50d6f prow.sh: enable building arm64 image
0d5bd843 Merge pull request #90 from pohly/k8s-staging-sig-storage
3df86b7d cloud build: k8s-staging-sig-storage
c5fd9610 Merge pull request #89 from pohly/cloud-build-binfmt
db0c2a7d cloud build: initialize support for running commands in Dockerfile
be902f40 Merge pull request #88 from pohly/multiarch-windows-fix
340e082f build.make: optional inclusion of Windows in multiarch images
5231f05d build.make: properly declare push-multiarch
4569f27a build.make: fix push-multiarch ambiguity
17dde9ef Merge pull request #87 from pohly/cloud-build
bd416901 cloud build: initial set of shared files
9084fecb Merge pull request #81 from msau42/add-release-process
6f2322e8 Update patch release notes generation command
0fcc3b1b Merge pull request #78 from ggriffiths/fix_csi_snapshotter_rbac_version_set
d8c76fee Support local snapshot RBAC for pull jobs
c1bdf5bf Merge pull request #80 from msau42/add-release-process
ea1f94aa update release tools instructions
152396e2 Merge pull request #77 from ggriffiths/snapshotter201_update
7edc1461 Update snapshotter to version 2.0.1
4cf843f6 Merge pull request #76 from pohly/build-targets
3863a0f6 build for multiple platforms only in CI, add s390x
8322a7d0 Merge pull request #72 from pohly/hostpath-update
7c5a89c8 prow.sh: use 1.3.0 hostpath driver for testing
b8587b2b Merge pull request #71 from wozniakjan/test-vet
fdb32183 Change 'make test-vet' to call 'go vet'
d717c8c4 Merge pull request #69 from pohly/test-driver-config
a1432bc9 Merge pull request #70 from pohly/kubelet-feature-gates
5f74333a prow.sh: also configure feature gates for kubelet
84f78b12 prow.sh: generic driver installation
3c34b4f2 Merge pull request #67 from windayski/fix-link
fa90abd0 fix incorrect link
ff3cc3f1 Merge pull request #54 from msau42/add-release-process
ac8a0212 Document the process for releasing a new sidecar
23be6525 Merge pull request #65 from msau42/update-hostpath
6582f2ff Update hostpath driver version to get fix for connection-timeout
4cc91745 Merge pull request #64 from ggriffiths/snapshotter_2_version_update
8191eab6 Update snapshotter to version v2.0.0
3c463fb1 Merge pull request #61 from msau42/enable-snapshots
8b0316c7 Fix overriding of junit results by using unique names for each e2e run
5f444b80 Merge pull request #60 from saad-ali/updateHostpathVersion
af9549b5 Update prow hostpath driver version to 1.3.0-rc2
f6c74b30 Merge pull request #57 from ggriffiths/version_gt_kubernetes_fix
fc809759 Fix version_gt to work with kubernetes prefix
9f1f3dd8 Merge pull request #56 from msau42/enable-snapshots
b98b2aed Enable snapshot tests in 1.17 to be run in non-alpha jobs.
9ace0204 Merge pull request #52 from msau42/update-readme
540599ba Merge pull request #53 from msau42/fix-make
a4e62996 fix syntax for ppc64le build
771ca6f2 Merge pull request #49 from ggriffiths/prowsh_improve_version_gt
d7c69d2f Merge pull request #51 from msau42/enable-multinode
4ad69492 Improve snapshot pod running checks and improve version_gt
53888ae7 Improve README by adding an explicit Kubernetes dependency section
9a7a685e Create a kind cluster with two worker nodes so that the topology feature can be tested. Test cases that test accessing volumes from multiple nodes need to be skipped
4ff2f5f0 Merge pull request #50 from darkowlzz/kind-0.6.0
80bba1fe Use kind v0.6.0
6d674a7f Merge pull request #47 from Pensu/multi-arch
8adde494 Merge pull request #45 from ggriffiths/snapshot_beta_crds
003c14b2 Add snapshotter CRDs after cluster setup
a41f3860 Merge pull request #46 from mucahitkurt/kind-cluster-cleanup
1eaaaa1c Delete kind cluster after tests run.
83a4ef15 Adding build for ppc64le
4fcafece Merge pull request #43 from pohly/system-pod-logging
f41c1351 prow.sh: also log output of system containers
ee22a9ca Merge pull request #42 from pohly/use-vendor-dir
80678456 travis.yml: also use vendor directory
23df4aef prow.sh: use vendor directory if available
a53bd4c4 Merge pull request #41 from pohly/go-version
c8a1c4af better handling of Go version
5e773d2d update CI to use Go 1.13.3
f419d745 Merge pull request #40 from msau42/add-1.16
e0fde8c4 Add new variables for 1.16 and remove 1.13
adf00fea Merge pull request #36 from msau42/full-clone
f1697d2c Do full git clones in travis. Shallow clones are causing test-subtree errors when the depth is exactly 50.
2c819198 Merge pull request #34 from pohly/go-mod-tidy
518d6af6 Merge pull request #35 from ddebroy/winbld2
2d6b3ce8 Build Windows only for amd64
c1078a65 go-get-kubernetes.sh: automate Kubernetes dependency handling
194289aa update Go mod support
0affdf95 Merge pull request #33 from gnufied/enable-hostpath-expansion
6208f6ab Enable hostpath expansion
6ecaa76e Merge pull request #30 from msau42/fix-windows
ea2f1b52 build windows binaries with .exe suffix
2d335506 Merge pull request #29 from mucahitkurt/create-2-node-kind-cluster
a8ea8bcc create 2-node kind cluster since topology support is added to hostpath driver
df8530d9 Merge pull request #27 from pohly/dep-vendor-check
35ceaedc prow.sh: install dep if needed
f85ab5af Merge pull request #26 from ddebroy/windows1
9fba09b4 Add rule for building Windows binaries
04008676 Merge pull request #25 from msau42/fix-master-jobs
dc0a5d83 Update kind to v0.5.0
aa85b82c Merge pull request #23 from msau42/fix-master-jobs
f46191d9 Kubernetes master changed the way that releases are tagged, which needed changes to kind. There are 3 changes made to prow.sh:
1cac3af3 Merge pull request #22 from msau42/add-1.15-jobs
0c0dc300 prow.sh: tag master images with a large version number
f4f73cef Merge pull request #21 from msau42/add-1.15-jobs
4e31f078 Change default hostpath driver name to hostpath.csi.k8s.io
4b6fa4a0 Update hostpath version for sidecar testing to v1.2.0-rc2
ecc79187 Update kind to v0.4.0. This requires overriding Kubernetes versions with specific patch versions that kind 0.4.0 supports. Also, feature gate setting is only supported on 1.15+ due to kind.sigs.k8s.io/v1alpha3 and kubeadm.k8s.io/v1beta2 dependencies.
a6f21d40 Add variables for 1.15
db8abb6e Merge pull request #20 from pohly/test-driver-config
b2f4e051 prow.sh: flexible test driver config
03999882 Merge pull request #19 from pohly/go-mod-vendor
066143d1 build.make: allow repos to use 'go mod' for vendoring
0bee7493 Merge pull request #18 from pohly/go-version
e157b6b5 update to Go 1.12.4
88dc9a47 Merge pull request #17 from pohly/prow
0fafc663 prow.sh: skip sanity testing if component doesn't support it
bcac1c1f Merge pull request #16 from pohly/prow
0b10f6a4 prow.sh: update csi-driver-host-path
0c2677e8 Merge pull request #15 from pengzhisun/master
ff9bce4a Replace 'return' to 'exit' to fix shellcheck error
c60f3823 Merge pull request #14 from pohly/prow
7aaac225 prow.sh: remove AllAlpha=all, part II
66177736 Merge pull request #13 from pohly/prow
cda2fc58 prow.sh: avoid AllAlpha=true
546d5504 prow.sh: debug failing KinD cluster creation
9b0d9cd7 build.make: skip shellcheck if Docker is not available
aa45a1cd prow.sh: more efficient execution of individual tests
f3d1d2df prow.sh: fix hostpath driver version check
31dfaf31 prow.sh: fix running of just "alpha" tests
f5014439 prow.sh: AllAlpha=true for unknown Kubernetes versions
95ae9de9 Merge pull request #9 from pohly/prow
d87eccb4 prow.sh: switch back to upstream csi-driver-host-path
6602d38b prow.sh: different E2E suite depending on Kubernetes version
741319bd prow.sh: improve building Kubernetes from source
29545bb0 prow.sh: take Go version from Kubernetes source
429581c5 prow.sh: pull Go version from travis.yml
0a0fd49b prow.sh: comment clarification
2069a0af Merge pull request #11 from pohly/verify-shellcheck
55212ff2 initial Prow test job
6c7ba1be build.make: integrate shellcheck into "make test"
b2d25d4f verify-shellcheck.sh: make it usable in csi-release-tools
3b6af7b1 Merge pull request #12 from pohly/local-e2e-suite
104a1ac9 build.make: avoid unit-testing E2E test suite
34010e75 Merge pull request #10 from pohly/vendor-check
e6db50df check vendor directory
fb13c519 verify-shellcheck.sh: import from Kubernetes
94fc1e31 build.make: avoid unit-testing E2E test suite
849db0ad Merge pull request #8 from pohly/subtree-check-relax
cc564f92 verify-subtree.sh: relax check and ignore old content
33d58fdc Merge pull request #5 from pohly/test-enhancements
be8a4400 Merge pull request #4 from pohly/canary-fix
b0336b55 build.make: more readable "make test" output
09436b9f build.make: fix pushing of "canary" image from master branch
147892c9 build.make: support suppressing checks
154e33d4 build.make: clarify usage of "make V=1"

git-subtree-dir: release-tools
git-subtree-split: a0f195cc2ddc2a1f07d4d3e46fc08187db358f94

```release-note
NONE
```