### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -69,12 +69,17 @@ endif
 # toolchain.
 BUILD_PLATFORMS =
 
+# Add go ldflags using LDFLAGS at the time of compilation.
+IMPORTPATH_LDFLAGS = -X main.version=$(REV) 
+EXT_LDFLAGS = -extldflags "-static"
+LDFLAGS = 
+FULL_LDFLAGS = $(LDFLAGS) $(IMPORTPATH_LDFLAGS) $(EXT_LDFLAGS)
 # This builds each command (= the sub-directories of ./cmd) for the target platform(s)
 # defined by BUILD_PLATFORMS.
 $(CMDS:%=build-%): build-%: check-go-version-go
 	mkdir -p bin
 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '$(FULL_LDFLAGS)' -o "./bin/$*$$suffix" ./cmd/$*); then \
 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
Squashed 'release-tools/' changes from a0f195cc..4aff857d

[4aff857d](https://github.com/kubernetes-csi/csi-release-tools/commit/4aff857d) Merge pull request #109 from pohly/alpha-test-defaults
[0427289d](https://github.com/kubernetes-csi/csi-release-tools/commit/0427289d) Merge pull request #110 from pohly/kind-0.9-bazel-build-workaround
[9a370ab9](https://github.com/kubernetes-csi/csi-release-tools/commit/9a370ab9) prow.sh: work around "kind build node-image" failure
[522361ec](https://github.com/kubernetes-csi/csi-release-tools/commit/522361ec) prow.sh: only run alpha tests for latest Kubernetes release
[22c0395c](https://github.com/kubernetes-csi/csi-release-tools/commit/22c0395c) Merge pull request #108 from bnrjee/master
[b5b447b5](https://github.com/kubernetes-csi/csi-release-tools/commit/b5b447b5) Add go ldflags using LDFLAGS at the time of compilation
[16f4afbd](https://github.com/kubernetes-csi/csi-release-tools/commit/16f4afbd) Merge pull request #107 from pohly/kind-update
[7bcee13d](https://github.com/kubernetes-csi/csi-release-tools/commit/7bcee13d) prow.sh: update to kind 0.9, support Kubernetes 1.19
[df518fbd](https://github.com/kubernetes-csi/csi-release-tools/commit/df518fbd) prow.sh: usage of Bazel optional
[c3afd427](https://github.com/kubernetes-csi/csi-release-tools/commit/c3afd427) Merge pull request #104 from xing-yang/snapshot
[dde93b22](https://github.com/kubernetes-csi/csi-release-tools/commit/dde93b22) Update to snapshot-controller v3.0.0

git-subtree-dir: release-tools
git-subtree-split: 4aff857d88149e07951fcd1322f462f765401a86

```release-note
NONE
```