### PR TITLE
added a destroy-script for the resources installed

### DIFF
--- a/deploy/kubernetes-1.18/destroy.sh
+++ b/deploy/kubernetes-1.18/destroy.sh
@@ -1,0 +1,1 @@
+../util/destroy-hostpath.sh

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-attacher.yaml
@@ -2,23 +2,34 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-attacher
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-attacher
+    app.kubernetes.io/component: attacher
 spec:
   serviceName: "csi-hostpath-attacher"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-attacher
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-attacher
+      app.kubernetes.io/component: attacher
   template:
     metadata:
       labels:
-        app: csi-hostpath-attacher
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-attacher
+        app.kubernetes.io/component: attacher
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
                 - csi-hostpathplugin

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-driverinfo.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-driverinfo.yaml
@@ -2,6 +2,11 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: hostpath.csi.k8s.io
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: hostpath.csi.k8s.io
+    app.kubernetes.io/component: csi-driver
 spec:
   # Supports persistent and ephemeral inline volumes.
   volumeLifecycleModes:

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
@@ -7,10 +7,16 @@ apiVersion: v1
 metadata:
   name: csi-hostpathplugin
   labels:
-    app: csi-hostpathplugin
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: plugin
 spec:
   selector:
-    app: csi-hostpathplugin
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: plugin
   ports:
     - name: dummy
       port: 12345
@@ -19,6 +25,11 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpathplugin
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: plugin
 spec:
   serviceName: "csi-hostpathplugin"
   # One replica only:
@@ -28,11 +39,17 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpathplugin
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpathplugin
+      app.kubernetes.io/component: plugin
   template:
     metadata:
       labels:
-        app: csi-hostpathplugin
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpathplugin
+        app.kubernetes.io/component: plugin
     spec:
       serviceAccountName: csi-external-health-monitor-controller
       containers:

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
@@ -2,23 +2,34 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-provisioner
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-provisioner
+    app.kubernetes.io/component: provisioner
 spec:
   serviceName: "csi-hostpath-provisioner"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-provisioner
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-provisioner
+      app.kubernetes.io/component: provisioner
   template:
     metadata:
       labels:
-        app: csi-hostpath-provisioner
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-provisioner
+        app.kubernetes.io/component: provisioner
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
                 - csi-hostpathplugin

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-resizer.yaml
@@ -2,23 +2,34 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-resizer
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-resizer
+    app.kubernetes.io/component: resizer
 spec:
   serviceName: "csi-hostpath-resizer"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-resizer
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-resizer
+      app.kubernetes.io/component: resizer
   template:
     metadata:
       labels:
-        app: csi-hostpath-resizer
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-resizer
+        app.kubernetes.io/component: resizer
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
                 - csi-hostpathplugin

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-snapshotter.yaml
@@ -2,23 +2,34 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-snapshotter
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-snapshotter
+    app.kubernetes.io/component: snapshotter
 spec:
   serviceName: "csi-hostpath-snapshotter"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-snapshotter
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-snapshotter
+      app.kubernetes.io/component: snapshotter
   template:
     metadata:
       labels:
-        app: csi-hostpath-snapshotter
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-snapshotter
+        app.kubernetes.io/component: snapshotter
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
                 - csi-hostpathplugin

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-testing.yaml
@@ -11,10 +11,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hostpath-service
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
 spec:
   type: NodePort
   selector:
-    app: csi-hostpath-socat
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
   ports:
   - port: 10000 # fixed port inside the pod, dynamically allocated port outside
 ---
@@ -22,23 +30,34 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-socat
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
 spec:
   serviceName: "csi-hostpath-socat"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-socat
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-socat
+      app.kubernetes.io/component: socat
   template:
     metadata:
       labels:
-        app: csi-hostpath-socat
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-socat
+        app.kubernetes.io/component: socat
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
                 - csi-hostpathplugin

--- a/deploy/kubernetes-1.18/snapshotter/csi-hostpath-snapshotclass.yaml
+++ b/deploy/kubernetes-1.18/snapshotter/csi-hostpath-snapshotclass.yaml
@@ -2,5 +2,10 @@ apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-hostpath-snapclass
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-snapclass
+    app.kubernetes.io/component: volumesnapshotclass
 driver: hostpath.csi.k8s.io #csi-hostpath
 deletionPolicy: Delete

--- a/deploy/kubernetes-1.20/destroy.sh
+++ b/deploy/kubernetes-1.20/destroy.sh
@@ -1,0 +1,1 @@
+../util/destroy-hostpath.sh

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-attacher.yaml
@@ -2,26 +2,37 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-attacher
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-attacher
+    app.kubernetes.io/component: attacher
 spec:
   serviceName: "csi-hostpath-attacher"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-attacher
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-attacher
+      app.kubernetes.io/component: attacher
   template:
     metadata:
       labels:
-        app: csi-hostpath-attacher
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-attacher
+        app.kubernetes.io/component: attacher
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                - csi-hostpathplugin
+                  - hostpath.csi.k8s.io
             topologyKey: kubernetes.io/hostname
       serviceAccountName: csi-attacher
       containers:

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-driverinfo.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-driverinfo.yaml
@@ -2,6 +2,11 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: hostpath.csi.k8s.io
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: hostpath.csi.k8s.io
+    app.kubernetes.io/component: csi-driver
 spec:
   # Supports persistent and ephemeral inline volumes.
   volumeLifecycleModes:

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
@@ -7,7 +7,10 @@ apiVersion: v1
 metadata:
   name: csi-hostpathplugin
   labels:
-    app: csi-hostpathplugin
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: plugin
 spec:
   selector:
     app: csi-hostpathplugin
@@ -19,6 +22,11 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpathplugin
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: plugin
 spec:
   serviceName: "csi-hostpathplugin"
   # One replica only:
@@ -28,11 +36,17 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpathplugin
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpathplugin
+      app.kubernetes.io/component: plugin
   template:
     metadata:
       labels:
-        app: csi-hostpathplugin
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpathplugin
+        app.kubernetes.io/component: plugin
     spec:
       serviceAccountName: csi-external-health-monitor-controller
       containers:

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-provisioner.yaml
@@ -2,26 +2,37 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-provisioner
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-provisioner
+    app.kubernetes.io/component: provisioner
 spec:
   serviceName: "csi-hostpath-provisioner"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-provisioner
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-provisioner
+      app.kubernetes.io/component: provisioner
   template:
     metadata:
       labels:
-        app: csi-hostpath-provisioner
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-provisioner
+        app.kubernetes.io/component: provisioner
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                - csi-hostpathplugin
+                  - hostpath.csi.k8s.io
             topologyKey: kubernetes.io/hostname
       serviceAccountName: csi-provisioner
       containers:

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-resizer.yaml
@@ -2,26 +2,37 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-resizer
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-resizer
+    app.kubernetes.io/component: resizer
 spec:
   serviceName: "csi-hostpath-resizer"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-resizer
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-resizer
+      app.kubernetes.io/component: resizer
   template:
     metadata:
       labels:
-        app: csi-hostpath-resizer
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-resizer
+        app.kubernetes.io/component: resizer
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                - csi-hostpathplugin
+                  - hostpath.csi.k8s.io
             topologyKey: kubernetes.io/hostname
       serviceAccountName: csi-resizer
       containers:

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-snapshotter.yaml
@@ -2,26 +2,37 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-snapshotter
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-snapshotter
+    app.kubernetes.io/component: snapshotter
 spec:
   serviceName: "csi-hostpath-snapshotter"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-snapshotter
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-snapshotter
+      app.kubernetes.io/component: snapshotter
   template:
     metadata:
       labels:
-        app: csi-hostpath-snapshotter
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-snapshotter
+        app.kubernetes.io/component: snapshotter
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                - csi-hostpathplugin
+                  - hostpath.csi.k8s.io
             topologyKey: kubernetes.io/hostname
       serviceAccountName: csi-snapshotter
       containers:

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-testing.yaml
@@ -11,10 +11,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hostpath-service
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
 spec:
   type: NodePort
   selector:
-    app: csi-hostpath-socat
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
   ports:
   - port: 10000 # fixed port inside the pod, dynamically allocated port outside
 ---
@@ -22,26 +30,37 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-socat
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
 spec:
   serviceName: "csi-hostpath-socat"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-socat
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-socat
+      app.kubernetes.io/component: socat
   template:
     metadata:
       labels:
-        app: csi-hostpath-socat
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-socat
+        app.kubernetes.io/component: socat
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                - csi-hostpathplugin
+                  - hostpath.csi.k8s.io
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat

--- a/deploy/kubernetes-1.20/snapshotter/csi-hostpath-snapshotclass.yaml
+++ b/deploy/kubernetes-1.20/snapshotter/csi-hostpath-snapshotclass.yaml
@@ -4,5 +4,10 @@ apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-hostpath-snapclass
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-snapclass
+    app.kubernetes.io/component: volumesnapshotclass
 driver: hostpath.csi.k8s.io #csi-hostpath
 deletionPolicy: Delete

--- a/deploy/kubernetes-distributed/app-generic-ephemeral.yaml
+++ b/deploy/kubernetes-distributed/app-generic-ephemeral.yaml
@@ -5,6 +5,11 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: my-csi-app-inline-volume
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-ephemral-inline-volume
+    app.kubernetes.io/component: ephemeral-volume
 spec:
   containers:
     - name: my-frontend

--- a/deploy/kubernetes-distributed/deploy.sh
+++ b/deploy/kubernetes-distributed/deploy.sh
@@ -13,6 +13,10 @@ set -o pipefail
 
 BASE_DIR=$(dirname "$0")
 
+TEMP_DIR="$( mktemp -d )"
+trap 'rm -rf ${TEMP_DIR}' EXIT
+
+
 # If set, the following env variables override image registry and/or tag for each of the images.
 # They are named after the image name, with hyphen replaced by underscore and in upper case.
 #
@@ -133,7 +137,28 @@ for component in CSI_PROVISIONER; do
         echo "Using non-default RBAC rules for $component. Changes from $original to $current are:"
         diff -c <(wget --quiet -O - "$original") <(if [[ "$current" =~ ^http ]]; then wget --quiet -O - "$current"; else cat "$current"; fi) || true
     fi
-    run kubectl apply -f "${current}"
+
+    # using kustomize kubectl plugin to add labels to he rbac files.
+    # since we are deploying rbas directly with the url, the kustomize plugin only works with the local files
+    # we need to add the files locally in temp folder and using kustomize adding labels it will be applied
+    if [[ "${current}" =~ ^http:// ]] || [[ "${current}" =~ ^https:// ]]; then
+      run curl "${current}" --output "${TEMP_DIR}"/rbac.yaml --silent --location
+      current=./rbac.yaml
+    fi
+
+    cat <<- EOF > "${TEMP_DIR}"/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app.kubernetes.io/instance: hostpath.csi.k8s.io
+  app.kubernetes.io/part-of: csi-driver-host-path
+
+resources:
+- ${current}
+EOF
+
+    run kubectl apply --kustomize "${TEMP_DIR}"
 done
 
 # The cluster must support exactly the version that the external-provisioner supports.

--- a/deploy/kubernetes-distributed/destroy.sh
+++ b/deploy/kubernetes-distributed/destroy.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script performs the step to destroy the hostpath plugin driver
+# completely by checking all the resources.
+# This should be in sync with the deploy script based on any future additions/deletions
+# of the resources
+
+# The script assumes that kubectl is available on the OS path
+# where it is executed.
+
+set -e
+set -o pipefail
+
+# Deleting all the resources installed by the deploy-script as the part of csi-hostpath-driver.
+# Every resource in the driver installation has the label representing the installation instance.
+# Using app.kubernetes.io/instance: hostpath.csi.k8s.io and app.kubernetes.io/part-of: csi-driver-host-path labels to identify the installation set
+#
+# kubectl maintains a few standard resources under "all" category which can be deleted by using just "kubectl delete all"
+# and other resources such as roles, clusterrole, serivceaccount etc needs to be deleted explicitly
+kubectl delete all --all-namespaces -l app.kubernetes.io/instance=hostpath.csi.k8s.io,app.kubernetes.io/part-of=csi-driver-host-path --wait=true
+kubectl delete role,clusterrole,rolebinding,clusterrolebinding,serviceaccount,storageclass,csidriver --all-namespaces -l app.kubernetes.io/instance=hostpath.csi.k8s.io,app.kubernetes.io/part-of=csi-driver-host-path --wait=true

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-driverinfo.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-driverinfo.yaml
@@ -2,6 +2,11 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: hostpath.csi.k8s.io
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: hostpath.csi.k8s.io
+    app.kubernetes.io/component: csi-driver
 spec:
   # Supports persistent and ephemeral inline volumes.
   volumeLifecycleModes:

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -2,14 +2,25 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpathplugin
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: plugin
 spec:
   selector:
     matchLabels:
-      app: csi-hostpathplugin
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpathplugin
+      app.kubernetes.io/component: plugin
   template:
     metadata:
       labels:
-        app: csi-hostpathplugin
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpathplugin
+        app.kubernetes.io/component: plugin
     spec:
       serviceAccountName: csi-provisioner
       containers:

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-storageclass-fast.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-storageclass-fast.yaml
@@ -2,6 +2,11 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: csi-hostpath-fast
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-fast
+    app.kubernetes.io/component: storageclass
 provisioner: hostpath.csi.k8s.io
 volumeBindingMode: WaitForFirstConsumer
 parameters:

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-storageclass-slow.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-storageclass-slow.yaml
@@ -2,6 +2,11 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: csi-hostpath-slow
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-slow
+    app.kubernetes.io/component: storageclass
 provisioner: hostpath.csi.k8s.io
 volumeBindingMode: WaitForFirstConsumer
 parameters:

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-testing.yaml
@@ -11,10 +11,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hostpath-service
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
 spec:
   type: NodePort
   selector:
-    app: csi-hostpath-socat
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
   ports:
   - port: 10000 # fixed port inside the pod, dynamically allocated port outside
 ---
@@ -22,26 +30,37 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-socat
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpath-socat
+    app.kubernetes.io/component: socat
 spec:
   serviceName: "csi-hostpath-socat"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-hostpath-socat
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpath-socat
+      app.kubernetes.io/component: socat
   template:
     metadata:
       labels:
-        app: csi-hostpath-socat
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpath-socat
+        app.kubernetes.io/component: socat
     spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                - csi-hostpathplugin
+                  - hostpath.csi.k8s.io
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat

--- a/deploy/util/destroy-hostpath.sh
+++ b/deploy/util/destroy-hostpath.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script performs the step to destroy the hostpath plugin driver
+# completely by checking all the resources.
+# This should be in sync with the deploy script based on any future additions/deletions
+# of the resources
+
+# The script assumes that kubectl is available on the OS path
+# where it is executed.
+
+set -e
+set -o pipefail
+
+# Deleting all the resources installed by the deploy-script as the part of csi-hostpath-driver.
+# Every resource in the driver installation has the label representing the installation instance.
+# Using app.kubernetes.io/instance: hostpath.csi.k8s.io and app.kubernetes.io/part-of: csi-driver-host-path labels to identify the installation set
+#
+# kubectl maintains a few standard resources under "all" category which can be deleted by using just "kubectl delete all"
+# and other resources such as roles, clusterrole, serivceaccount etc needs to be deleted explicitly
+kubectl delete all --all-namespaces -l app.kubernetes.io/instance=hostpath.csi.k8s.io,app.kubernetes.io/part-of=csi-driver-host-path --wait=true
+kubectl delete role,clusterrole,rolebinding,clusterrolebinding,serviceaccount,storageclass,csidriver --all-namespaces -l app.kubernetes.io/instance=hostpath.csi.k8s.io,app.kubernetes.io/part-of=csi-driver-host-path --wait=true


### PR DESCRIPTION
- added labels to the resources

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Need a cleanup script to delete all the installed resources

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-csi/csi-driver-host-path/issues/212

**Does this PR introduce a user-facing change?**:
NONE

```release-note
All the csi resources from k8s 1.17 will be having a common label `partof: csi-hostpath-driver` which will be used to collectively identify all the resources under csi installation and also can be used to delete them in bulk
```
