### PR TITLE
added the fix for script for not being able to use in script source path

### DIFF
--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -11,7 +11,7 @@
 set -e
 set -o pipefail
 
-BASE_DIR=$(dirname "$0")
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # If set, the following env variables override image registry and/or tag for each of the images.
 # They are named after the image name, with hyphen replaced by underscore and in upper case.

--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -11,7 +11,7 @@
 set -e
 set -o pipefail
 
-BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BASE_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 # If set, the following env variables override image registry and/or tag for each of the images.
 # They are named after the image name, with hyphen replaced by underscore and in upper case.


### PR DESCRIPTION

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
The csi driver deployment script was using the base path as the curr dir where the script is triggerred, csi-snapshot class was not getting installed because of incorrect path resolution. Fixed to use the base path always using pwd and cd


**Which issue(s) this PR fixes**:

Fixes #https://github.com/kubernetes-csi/csi-driver-host-path/issues/199

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Added the Fix for path resolution in deploy script. Now the user can run script from anywhere, not necessarily from the base path as `./deploy/kubernetes-1.1x/depploy-script.sh`
```
