### PR TITLE
Make raw block pvc creation from volume snapshot idempotent

### DIFF
--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -134,7 +134,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			volumeSource := req.VolumeContentSource
 			switch volumeSource.Type.(type) {
 			case *csi.VolumeContentSource_Snapshot:
-				if volumeSource.GetSnapshot() != nil && exVol.ParentSnapID != volumeSource.GetSnapshot().GetSnapshotId() {
+				if volumeSource.GetSnapshot() != nil && exVol.ParentSnapID != "" && exVol.ParentSnapID != volumeSource.GetSnapshot().GetSnapshotId() {
 					return nil, status.Error(codes.AlreadyExists, "existing volume source snapshot id not matching")
 				}
 			case *csi.VolumeContentSource_Volume:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Previously, the `dd` command run at https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/pkg/hostpath/hostpath.go#L334 for raw block volumes was taking longer than the timeout for `CreateVolume`. As a result, the first call to `CreateVolume` fails with `DeadlineExceeded`. 

Subsequent calls to `CreateVolume` were failing at https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/pkg/hostpath/controllerserver.go#L138 because this volume was added to the local cache in the first call.

This PR makes creation of raw block PVC's from volume snapshots idempotent, so that retries for the same volume succeed. 

Testing:
1. Create raw block PVC
2. Create volume snapshot
3. Create new PVC with volume snapshot as source

Both PVC's are in Bound state:
```
$ kubectl get  pvc
NAME              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
pvc-raw           Bound    pvc-e8b2e03e-e2be-462e-aea4-4c6eab52ff95   1Gi        RWO            csi-hostpath-sc   3m59s
raw-pvc-restore   Bound    pvc-9fd5af15-ceb6-4fd9-b6d9-6e131b54b55b   1Gi        RWO            csi-hostpath-sc   2m56s

$ kubectl get volumesnapshot
NAME               READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS            SNAPSHOTCONTENT                                    CREATIONTIME   AGE
raw-pvc-snapshot   true         pvc-raw                             1Gi           csi-hostpath-snapclass   snapcontent-d2bac861-3ba2-4839-a85e-b06674041cd4   3m27s          4m11s
```

 Logs showing CreateVolume is called twice: 
```
I1111 17:57:25.570725       1 server.go:117] GRPC call: /csi.v1.Controller/CreateVolume
I1111 17:57:25.570775       1 server.go:118] GRPC request: {"accessibility_requirements":{"preferred":[{"segments":{"topology.hostpath.csi/node":"csi-prow-worker"}}],"requisite":[{"segments":{"topology.hostpath.csi/node":"csi-prow-worker"}}]},"capacity_range":{"required_bytes":1073741824},"name":"pvc-9fd5af15-ceb6-4fd9-b6d9-6e131b54b55b","volume_capabilities":[{"AccessType":{"Block":{}},"access_mode":{"mode":1}}],"volume_content_source":{"Type":{"Snapshot":{"snapshot_id":"53ff081f-2447-11eb-bed8-1ec29f23ce4b"}}}}
I1111 17:57:25.650608       1 volume_path_handler_linux.go:41] Creating device for path: /csi-data-dir/5b2b7374-2447-11eb-bed8-1ec29f23ce4b
I1111 17:57:25.668637       1 controllerserver.go:165] created volume 5b2b7374-2447-11eb-bed8-1ec29f23ce4b at path /csi-data-dir/5b2b7374-2447-11eb-bed8-1ec29f23ce4b
I1111 17:57:26.591090       1 server.go:117] GRPC call: /csi.v1.Controller/CreateVolume
I1111 17:57:26.591117       1 server.go:118] GRPC request: {"accessibility_requirements":{"preferred":[{"segments":{"topology.hostpath.csi/node":"csi-prow-worker"}}],"requisite":[{"segments":{"topology.hostpath.csi/node":"csi-prow-worker"}}]},"capacity_range":{"required_bytes":1073741824},"name":"pvc-9fd5af15-ceb6-4fd9-b6d9-6e131b54b55b","volume_capabilities":[{"AccessType":{"Block":{}},"access_mode":{"mode":1}}],"volume_content_source":{"Type":{"Snapshot":{"snapshot_id":"53ff081f-2447-11eb-bed8-1ec29f23ce4b"}}}}
I1111 17:57:26.593464       1 server.go:123] GRPC response: {"volume":{"capacity_bytes":1073741824,"content_source":{"Type":{"Snapshot":{"snapshot_id":"53ff081f-2447-11eb-bed8-1ec29f23ce4b"}}},"volume_id":"5b2b7374-2447-11eb-bed8-1ec29f23ce4b"}}
```

Get volumeHandle of PV's:
```
$ kubectl describe pv  | grep -i handle
    VolumeHandle:      5b2b7374-2447-11eb-bed8-1ec29f23ce4b
    VolumeHandle:      35df4fe4-2447-11eb-bed8-1ec29f23ce4b
```


Exec into the hostpath driver and verify that only 3 volumes exist (2 with PV volume handles):
```
/ # ls /csi-data-dir/
35df4fe4-2447-11eb-bed8-1ec29f23ce4b       53ff081f-2447-11eb-bed8-1ec29f23ce4b.snap  5b2b7374-2447-11eb-bed8-1ec29f23ce4b
```

Verify that only two volumes are attached:
```
/ # losetup
NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE                                          DIO LOG-SEC
/dev/loop1         0      0         0  0 /csi-data-dir/5b2b7374-2447-11eb-bed8-1ec29f23ce4b   0     512
/dev/loop0         0      0         0  0 /csi-data-dir/35df4fe4-2447-11eb-bed8-1ec29f23ce4b   0     512
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #219

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Make raw block PVC creation from VolumeSnapshot idempotent.
```
