### PR TITLE
Fix deploy test-driver SizeRange and add logs

### DIFF
--- a/deploy/kubernetes-1.17/test-driver.yaml
+++ b/deploy/kubernetes-1.17/test-driver.yaml
@@ -8,6 +8,8 @@ SnapshotClass:
   FromName: true
 DriverInfo:
   Name: hostpath.csi.k8s.io
+  SupportedSizeRange:
+    Min: 1Mi
   Capabilities:
     block: true
     controllerExpansion: true

--- a/docs/example-snapshots-1.17-and-later.md
+++ b/docs/example-snapshots-1.17-and-later.md
@@ -18,7 +18,7 @@ Ensure your volumesnapshotclass was created during hostpath deployment:
 > $ kubectl describe volumesnapshotclass
 > ```
 > Name:             csi-hostpath-snapclass
-> Namespace:        
+> Namespace:
 > Labels:           <none>
 > Annotations:      kubectl.kubernetes.io/last-applied-configuration:
 >                     {"apiVersion":"snapshot.storage.k8s.io/v1beta1","deletionPolicy":"Delete","driver":"hostpath.csi.k8s.io","kind":"VolumeSnapshotClass","met...
@@ -89,7 +89,7 @@ use the volume snapshot class to dynamically create a volume snapshot:
 > $ kubectl describe volumesnapshotcontent
 > ```
 > Name:         snapcontent-1b461d4e-6279-4f1d-9910-61d35d80c888
-> Namespace:    
+> Namespace:
 > Labels:       <none>
 > Annotations:  <none>
 > API Version:  snapshot.storage.k8s.io/v1beta1
@@ -126,6 +126,7 @@ use the volume snapshot class to dynamically create a volume snapshot:
 ## Restore volume from snapshot support
 
 Follow the following example to create a volume from a volume snapshot:
+Note that as the PVC size goes larger, the restore can be slower.
 
 > $ kubectl apply -f examples/csi-restore.yaml
 > `persistentvolumeclaim/hpvc-restore created`

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -187,6 +187,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			err = status.Errorf(codes.InvalidArgument, "%v not a proper volume source", volumeSource)
 		}
 		if err != nil {
+			glog.V(4).Infof("VolumeSource error: %v", err)
 			if delErr := deleteHostpathVolume(volumeID); delErr != nil {
 				glog.V(2).Infof("deleting hostpath volume %v failed: %v", volumeID, delErr)
 			}

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -344,7 +344,9 @@ func loadFromSnapshot(size int64, snapshotId, destPath string, mode accessType) 
 	}
 
 	executor := utilexec.New()
+	glog.V(4).Infof("Command Start: %v", cmd)
 	out, err := executor.Command(cmd[0], cmd[1:]...).CombinedOutput()
+	glog.V(4).Infof("Command Finish: %v", string(out))
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed pre-populate data from snapshot %v: %v: %s", snapshotId, err, out)
 	}

--- a/pkg/hostpath/server.go
+++ b/pkg/hostpath/server.go
@@ -114,6 +114,9 @@ func parseEndpoint(ep string) (string, string, error) {
 }
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	if info.FullMethod == "/csi.v1.Identity/Probe" {
+		return handler(ctx, req)
+	}
 	glog.V(3).Infof("GRPC call: %s", info.FullMethod)
 	glog.V(5).Infof("GRPC request: %+v", protosanitizer.StripSecrets(req))
 	resp, err := handler(ctx, req)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR does the following:
1. Add MinSizeRange for hostpath test-driver so the sig-storage test could pass
2. Add some logging for triage in the future
3. Add doc about the restore process time

This fix is mainly to fix a sig-storage test: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-csi-1-19-on-kubernetes-master/1337029920152358912

The bug is captured because we add the defaultSizeRange in the external driver parsing. And that can lead to very slow block snapshot creation and leads to test failure.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
