### PR TITLE
fix: use exec.LookPath function

### DIFF
--- a/pkg/hostpath/healthcheck.go
+++ b/pkg/hostpath/healthcheck.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/golang/glog"
@@ -47,21 +46,6 @@ type ContainerFileSystem struct {
 
 type FileSystems struct {
 	Filsystem []ContainerFileSystem `json:"filesystems"`
-}
-
-func locateCommandPath(commandName string) string {
-	// default to root
-	binary := filepath.Join("/", commandName)
-	for _, path := range []string{"/bin", "/usr/sbin", "/usr/bin"} {
-		binPath := filepath.Join(path, binary)
-		if _, err := os.Stat(binPath); err != nil {
-			continue
-		}
-
-		return binPath
-	}
-
-	return ""
 }
 
 func getSourcePath(volumeHandle string) string {
@@ -100,7 +84,11 @@ func parseMountInfo(originalMountInfo []byte) ([]MountPointInfo, error) {
 }
 
 func checkMountPointExist(sourcePath string) (bool, error) {
-	cmdPath := locateCommandPath("findmnt")
+	cmdPath, err := exec.LookPath("findmnt")
+	if err != nil {
+		return false, fmt.Errorf("findmnt not found: %w", err)
+	}
+
 	out, err := exec.Command(cmdPath, "--json").CombinedOutput()
 	if err != nil {
 		glog.V(3).Infof("failed to execute command: %+v", cmdPath)

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -177,7 +177,11 @@ func (h *hostPath) discoverExistingSnapshots() {
 }
 
 func (hp *hostPath) discoveryExistingVolumes() error {
-	cmdPath := locateCommandPath("findmnt")
+	cmdPath, err := exec.LookPath("findmnt")
+	if err != nil {
+		return fmt.Errorf("findmnt not found: %w", err)
+	}
+
 	out, err := exec.Command(cmdPath, "--json").CombinedOutput()
 	if err != nil {
 		glog.V(3).Infof("failed to execute command: %+v", cmdPath)


### PR DESCRIPTION
This function us standard PATH environment variable


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Use standard function `exec.LookPath` instead of custom wrote.

**Special notes for your reviewer**:

Is it a wanted behavior to have path hard-coded? And why

**Does this PR introduce a user-facing change?**:

no

```release-note
Use exec.LookPath function
```
