### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/README.md
+++ b/release-tools/README.md
@@ -44,10 +44,17 @@ is the recommended way of maintaining a copy of the rules inside the
 changes also locally, test them and then push them back to the shared
 repository at a later time.
 
+We no longer care about importing the full commit history, so `--squash` should be used
+when submitting a `release-tools` update. Also make sure that the PR for that
+contains the automatically generated commit message in the PR description.
+It contains the list of individual commits that were squashed. The script from
+https://github.com/kubernetes-csi/csi-release-tools/issues/7 can create such
+PRs automatically.
+
 Cheat sheet:
 
-- `git subtree add --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master` - add release tools to a repo which does not have them yet (only once)
-- `git subtree pull --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master` - update local copy to latest upstream (whenever upstream changes)
+- `git subtree add --squash --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master` - add release tools to a repo which does not have them yet (only once)
+- `git subtree pull --squash --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master` - update local copy to latest upstream (whenever upstream changes)
 - edit, `git commit`, `git subtree push --prefix=release-tools git@github.com:<user>/csi-release-tools.git <my-new-or-existing-branch>` - push to a new branch before submitting a PR
 
 verify-shellcheck.sh

--- a/release-tools/boilerplate/boilerplate.py
+++ b/release-tools/boilerplate/boilerplate.py
@@ -19,8 +19,6 @@ from __future__ import print_function
 import argparse
 import difflib
 import glob
-import json
-import mmap
 import os
 import re
 import sys
@@ -33,12 +31,12 @@ parser.add_argument(
     nargs='*')
 
 # Rootdir defaults to the directory **above** the repo-infra dir.
-rootdir = os.path.dirname(__file__) + "./../../../"
+rootdir = os.path.dirname(__file__) + "./../../"
 rootdir = os.path.abspath(rootdir)
 parser.add_argument(
     "--rootdir", default=rootdir, help="root directory to examine")
 
-default_boilerplate_dir = os.path.join(rootdir, "csi-driver-nfs/hack/boilerplate")
+default_boilerplate_dir = os.path.abspath(os.path.dirname(__file__))
 
 parser.add_argument(
     "--boilerplate-dir", default=default_boilerplate_dir)

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -71,7 +71,7 @@ version_to_git () {
     version="$1"
     shift
     case "$version" in
-        latest) echo "master";;
+        latest|master) echo "master";;
         release-*) echo "$version";;
         *) echo "v$version";;
     esac


### PR DESCRIPTION
Squashed 'release-tools/' changes from 1d60e779..7bc70e52

[7bc70e52](https://github.com/kubernetes-csi/csi-release-tools/commit/7bc70e52) Merge pull request #129 from pohly/squash-documentation
[e0b02e72](https://github.com/kubernetes-csi/csi-release-tools/commit/e0b02e72) README.md: document usage of --squash
[316cb957](https://github.com/kubernetes-csi/csi-release-tools/commit/316cb957) Merge pull request #132 from yiyang5055/bugfix/boilerplate
[26e2ab10](https://github.com/kubernetes-csi/csi-release-tools/commit/26e2ab10) fix: default boilerplate path
[1add8c18](https://github.com/kubernetes-csi/csi-release-tools/commit/1add8c18) Merge pull request #133 from pohly/kubernetes-1.20-tag
[3e811d6c](https://github.com/kubernetes-csi/csi-release-tools/commit/3e811d6c) prow.sh: fix "on-master" prow jobs

git-subtree-dir: release-tools
git-subtree-split: 7bc70e5264a5ce5f47780bdbc6c7b7f4e79243fa

```release-note
NONE
```