### PR TITLE
release v1.6.0

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -1,0 +1,24 @@
+# Release notes for v1.6.0
+
+[Documentation](https://kubernetes-csi.github.io)
+
+# Changelog since v1.5.0
+
+## Changes by Kind
+
+### Feature
+ - Simulate storage capacity constraints and publish available capacity information ([#248](https://github.com/kubernetes-csi/csi-driver-host-path/pull/248), [@pohly](https://github.com/pohly))
+
+### Other (Cleanup or Flake)
+ - Image updates and deployment for Kubernetes 1.20 with external-snapshotter v4.0.0. ([#238](https://github.com/kubernetes-csi/csi-driver-host-path/pull/238), [@pohly](https://github.com/pohly))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
@@ -91,7 +91,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.5.0
+          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.6.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
@@ -91,7 +91,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.5.0
+          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.6.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

A new formal release is needed to publish the hostpath images which then enables the usage in Kubernetes E2E tests for 1.21.

**Special notes for your reviewer**:

The image versions gets bumped now to ensure that the release has YAML files which actually use the release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
