### PR TITLE
test: select node for late binding tests

### DIFF
--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -245,4 +245,11 @@ fi
 # expects it?
 if [ "${CSI_PROW_TEST_DRIVER}" ]; then
     cp "${BASE_DIR}/test-driver.yaml" "${CSI_PROW_TEST_DRIVER}"
+
+    # When testing late binding, pods must be forced to run on the
+    # same node as the hostpath driver. external-provisioner currently
+    # doesn't handle the case when the "wrong" node is chosen and gets
+    # stuck permanently with:
+    # error generating accessibility requirements: no topology key found on CSINode csi-prow-worker2
+    echo >>"${CSI_PROW_TEST_DRIVER}" "ClientNodeName: $(kubectl get pods/csi-hostpath-provisioner-0  -o jsonpath='{.spec.nodeName}')"
 fi


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

The generic ephemeral volume test runs with a variant that uses late
binding and that failed when the selected node didn't have the driver:

```
E0301 08:28:16.192962       1 controller.go:984] error syncing claim "17c6176b-3ea7-4363-bc35-eb25c2c20f4e": failed to provision volume with StorageClass "ephemeral-9299-e2e-scmtzhx": error generating accessibility requirements: no topology key found on CSINode csi-prow-worker2
```

The in-tree hostpath driver deployment avoids that by setting the node
on which test pods may run:
https://github.com/kubernetes/kubernetes/blob/793390e13be91d79150b57abad5710477ab96bd7/test/e2e/storage/drivers/csi.go#L193

We need to do the same when testing the driver externally.

**Which issue(s) this PR fixes**:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-csi-alpha-canary-on-kubernetes-master/1366289824465555456

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
