### PR TITLE
CSI ephemeral inline volume testing + fix

### DIFF
--- a/deploy/kubernetes-1.18/test-driver.yaml
+++ b/deploy/kubernetes-1.18/test-driver.yaml
@@ -20,3 +20,5 @@ DriverInfo:
     singleNodeVolume: true
     snapshotDataSource: true
     topology: true
+InlineVolumes:
+- shared: true

--- a/deploy/kubernetes-1.20/test-driver.yaml
+++ b/deploy/kubernetes-1.20/test-driver.yaml
@@ -20,3 +20,5 @@ DriverInfo:
     singleNodeVolume: true
     snapshotDataSource: true
     topology: true
+InlineVolumes:
+- shared: true

--- a/deploy/kubernetes-distributed/test-driver.yaml
+++ b/deploy/kubernetes-distributed/test-driver.yaml
@@ -16,3 +16,5 @@ DriverInfo:
     persistence: true
     singleNodeVolume: true
     topology: true
+InlineVolumes:
+- shared: true

--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -64,7 +64,9 @@ func (hp *hostPath) NodePublishVolume(ctx context.Context, req *csi.NodePublishV
 		volID := req.GetVolumeId()
 		volName := fmt.Sprintf("ephemeral-%s", volID)
 		kind := req.GetVolumeContext()[storageKind]
-		vol, err := hp.createVolume(req.GetVolumeId(), volName, maxStorageCapacity, mountAccess, ephemeralVolume, kind)
+		// Configurable size would be nice. For now we use a small, fixed volume size of 100Mi.
+		volSize := int64(100 * 1024 * 1024)
+		vol, err := hp.createVolume(req.GetVolumeId(), volName, volSize, mountAccess, ephemeralVolume, kind)
 		if err != nil && !os.IsExist(err) {
 			glog.Error("ephemeral mode failed to create volume: ", err)
 			return nil, err


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

At least one line volume must be defined, otherwise the tests
get skipped. This wasn't the case earlier, which is why support for CSI ephemeral inline volumes broke in release v1.6.0 when changing the size check.

**Does this PR introduce a user-facing change?**:
```release-note
CSI ephemeral inline volumes failed to get created with an error saying `MountVolume.SetUp failed for volume "ephemeral-volume" : rpc error: code = OutOfRange desc = Requested capacity 1099511627776 exceeds maximum allowed 1099511627776`
```
