### PR TITLE
Copy features from Mock CSI driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository hosts the CSI Hostpath driver and all of its build and dependent configuration files to deploy the driver.
 
+---
+*WARNING: This driver is just a demo implementation and is used for CI testing. This has many fake implementations and other non-standard best practices, and should not be used as an example of how to write a real driver.
+---
+
 ## Pre-requisite
 - Kubernetes cluster
 - Running version 1.13 or later

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ This repository hosts the CSI Hostpath driver and all of its build and dependent
 - Access to terminal with `kubectl` installed
 - For Kubernetes 1.17 or later, the VolumeSnapshot beta CRDs and Snapshot Controller must be installed as part of the cluster deployment (see Kubernetes 1.17+ deployment instructions)
 
+## Features
+
+The driver can provide empty directories that are backed by the same filesystem as EmptyDir volumes. In addition, it can provide raw block volumes that are backed by a single file in that same filesystem and bound to a loop device.
+
+[Various command line parameters](cmd/hostpathplugin/maing.go) influence the behavior of the driver. This is relevant in particular for the end-to-end testing that this driver is used for in Kubernetes.
+
+Usually, the driver implements all CSI operations itself. When deployed with the `-proxy-endpoint` parameter, it instead proxies all incoming connections for a CSI driver that is [embedded inside the Kubernetes E2E test suite](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/drivers/csi-test) and used for mocking a CSI driver [with callbacks provided by certain tests](https://github.com/kubernetes/kubernetes/blob/5ad79eae2dcbf33df3b35c48ec993d30fbda46dd/test/e2e/storage/csi_mock_volume.go#L110).
+
 ## Deployment
 Deployment varies depending on the Kubernetes version your cluster is running:
 - [Deployment for Kubernetes 1.17 and later](docs/deploy-1.17-and-later.md)

--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -41,6 +41,7 @@ var (
 		flag.Var(c, "capacity", "Simulate storage capacity. The parameter is <kind>=<quantity> where <kind> is the value of a 'kind' storage class parameter and <quantity> is the total amount of bytes for that kind. The flag may be used multiple times to configure different kinds.")
 		return c
 	}()
+	enableAttach = flag.Bool("enable-attach", false, "Enables RPC_PUBLISH_UNPUBLISH_VOLUME capability.")
 	// Set by the build process
 	version = ""
 )
@@ -58,7 +59,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Deprecation warning: The ephemeral flag is deprecated and should only be used when deploying on Kubernetes 1.15. It will be removed in the future.")
 	}
 
-	driver, err := hostpath.NewHostPathDriver(*driverName, *nodeID, *endpoint, *ephemeral, *maxVolumesPerNode, version, capacity)
+	driver, err := hostpath.NewHostPathDriver(*driverName, *nodeID, *endpoint, *ephemeral, *maxVolumesPerNode, version, capacity, *enableAttach)
 	if err != nil {
 		fmt.Printf("Failed to initialize driver: %s", err.Error())
 		os.Exit(1)

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+func Parse(ep string) (string, string, error) {
+	if strings.HasPrefix(strings.ToLower(ep), "unix://") || strings.HasPrefix(strings.ToLower(ep), "tcp://") {
+		s := strings.SplitN(ep, "://", 2)
+		if s[1] != "" {
+			return s[0], s[1], nil
+		}
+		return "", "", fmt.Errorf("Invalid endpoint: %v", ep)
+	}
+	// Assume everything else is a file path for a Unix Domain Socket.
+	return "unix", ep, nil
+}
+
+func Listen(endpoint string) (net.Listener, func(), error) {
+	proto, addr, err := Parse(endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cleanup := func() {}
+	if proto == "unix" {
+		addr = "/" + addr
+		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) { //nolint: vetshadow
+			return nil, nil, fmt.Errorf("%s: %q", addr, err)
+		}
+		cleanup = func() {
+			os.Remove(addr)
+		}
+	}
+
+	l, err := net.Listen(proto, addr)
+	return l, cleanup, err
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package proxy makes it possible to forward a listening socket in
+// situations where the proxy cannot connect to some other address.
+// Instead, it creates two listening sockets, pairs two incoming
+// connections and then moves data back and forth. This matches
+// the behavior of the following socat command:
+// socat -d -d -d UNIX-LISTEN:/tmp/socat,fork TCP-LISTEN:9000,reuseport
+//
+// The advantage over that command is that both listening
+// sockets are always open, in contrast to the socat solution
+// where the TCP port is only open when there actually is a connection
+// available.
+//
+// To establish a connection, someone has to poll the proxy with a dialer.
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/golang/glog"
+
+	"github.com/kubernetes-csi/csi-driver-host-path/internal/endpoint"
+)
+
+// New listens on both endpoints and starts accepting connections
+// until closed or the context is done.
+func Run(ctx context.Context, endpoint1, endpoint2 string) (io.Closer, error) {
+	proxy := &proxy{}
+	failedProxy := proxy
+	defer func() {
+		if failedProxy != nil {
+			failedProxy.Close()
+		}
+	}()
+
+	proxy.ctx, proxy.cancel = context.WithCancel(ctx)
+
+	var err error
+	proxy.s1, proxy.cleanup1, err = endpoint.Listen(endpoint1)
+	if err != nil {
+		return nil, fmt.Errorf("listen %s: %v", endpoint1, err)
+	}
+	proxy.s2, proxy.cleanup2, err = endpoint.Listen(endpoint2)
+	if err != nil {
+		return nil, fmt.Errorf("listen %s: %v", endpoint2, err)
+	}
+
+	glog.V(3).Infof("proxy listening on %s and %s", endpoint1, endpoint2)
+
+	go func() {
+		for {
+			// We block on the first listening socket.
+			// The Linux kernel proactively accepts connections
+			// on the second one which we will take over below.
+			conn1 := accept(proxy.ctx, proxy.s1, endpoint1)
+			if conn1 == nil {
+				// Done, shut down.
+				glog.V(5).Infof("proxy endpoint %s closed, shutting down", endpoint1)
+				return
+			}
+			conn2 := accept(proxy.ctx, proxy.s2, endpoint2)
+			if conn2 == nil {
+				// Done, shut down. The already accepted
+				// connection gets closed.
+				glog.V(5).Infof("proxy endpoint %s closed, shutting down and close established connection", endpoint2)
+				conn1.Close()
+				return
+			}
+
+			glog.V(3).Infof("proxy established a new connection between %s and %s", endpoint1, endpoint2)
+			go copy(conn1, conn2, endpoint1, endpoint2)
+			go copy(conn2, conn1, endpoint2, endpoint1)
+		}
+	}()
+
+	failedProxy = nil
+	return proxy, nil
+}
+
+type proxy struct {
+	ctx                context.Context
+	cancel             func()
+	s1, s2             net.Listener
+	cleanup1, cleanup2 func()
+}
+
+func (p *proxy) Close() error {
+	if p.cancel != nil {
+		p.cancel()
+	}
+	if p.s1 != nil {
+		p.s1.Close()
+	}
+	if p.s2 != nil {
+		p.s2.Close()
+	}
+	if p.cleanup1 != nil {
+		p.cleanup1()
+	}
+	if p.cleanup2 != nil {
+		p.cleanup2()
+	}
+	return nil
+}
+
+func copy(from, to net.Conn, fromEndpoint, toEndpoint string) {
+	glog.V(5).Infof("starting to copy %s -> %s", fromEndpoint, toEndpoint)
+	// Signal recipient that no more data is going to come.
+	// This also stops reading from it.
+	defer to.Close()
+	// Copy data until EOF.
+	cnt, err := io.Copy(to, from)
+	glog.V(5).Infof("done copying %s -> %s: %d bytes, %v", fromEndpoint, toEndpoint, cnt, err)
+}
+
+func accept(ctx context.Context, s net.Listener, endpoint string) net.Conn {
+	for {
+		c, err := s.Accept()
+		if err == nil {
+			return c
+		}
+		// Ignore error if we are shutting down.
+		if ctx.Err() != nil {
+			return nil
+		}
+		glog.V(3).Infof("accept on %s failed: %v", endpoint, err)
+	}
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+)
+
+func TestProxy(t *testing.T) {
+	tmpdir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	endpoint1 := tmpdir + "/a.sock"
+	endpoint2 := tmpdir + "/b.sock"
+
+	closer, err := Run(ctx, endpoint1, endpoint2)
+	if err != nil {
+		t.Fatalf("proxy error: %v", err)
+	}
+	defer closer.Close()
+
+	t.Run("a-to-b", func(t *testing.T) {
+		sendReceive(t, endpoint1, endpoint2)
+	})
+	t.Run("b-to-a", func(t *testing.T) {
+		sendReceive(t, endpoint2, endpoint1)
+	})
+}
+
+func sendReceive(t *testing.T, endpoint1, endpoint2 string) {
+	conn1, err := net.Dial("unix", endpoint1)
+	if err != nil {
+		t.Fatalf("error connecting to first endpoint %s: %v", endpoint1, err)
+	}
+	defer conn1.Close()
+	conn2, err := net.Dial("unix", endpoint2)
+	if err != nil {
+		t.Fatalf("error connecting to second endpoint %s: %v", endpoint2, err)
+	}
+	defer conn2.Close()
+
+	req1 := "ping"
+	if _, err := conn1.Write([]byte(req1)); err != nil {
+		t.Fatalf("error writing %q: %v", req1, err)
+	}
+	buffer := make([]byte, 100)
+	len, err := conn2.Read(buffer)
+	if err != nil {
+		t.Fatalf("error reading %q: %v", req1, err)
+	}
+	if string(buffer[:len]) != req1 {
+		t.Fatalf("expected %q, got %q", req1, string(buffer[:len]))
+	}
+
+	resp1 := "pong-pong"
+	if _, err := conn2.Write([]byte(resp1)); err != nil {
+		t.Fatalf("error writing %q: %v", resp1, err)
+	}
+	buffer = make([]byte, 100)
+	len, err = conn1.Read(buffer)
+	if err != nil {
+		t.Fatalf("error reading %q: %v", resp1, err)
+	}
+	if string(buffer[:len]) != resp1 {
+		t.Fatalf("expected %q, got %q", resp1, string(buffer[:len]))
+	}
+
+	// Closing one side should be noticed at the other end.
+	err = conn1.Close()
+	if err != nil {
+		t.Fatalf("error closing connection to %s: %v", endpoint1, err)
+	}
+	len2, err := io.Copy(&bytes.Buffer{}, conn2)
+	if err != nil {
+		t.Fatalf("error reading from %s: %v", endpoint2, err)
+	}
+	if len2 != 0 {
+		t.Fatalf("unexpected data via %s: %d", endpoint2, len2)
+	}
+	err = conn2.Close()
+	if err != nil {
+		t.Fatalf("error closing connection to %s: %v", endpoint2, err)
+	}
+}

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -99,9 +99,9 @@ func (hp *hostPath) CreateVolume(ctx context.Context, req *csi.CreateVolumeReque
 	defer hp.mutex.Unlock()
 
 	capacity := int64(req.GetCapacityRange().GetRequiredBytes())
-	topologies := []*csi.Topology{&csi.Topology{
-		Segments: map[string]string{TopologyKeyNode: hp.nodeID},
-	}}
+	topologies := []*csi.Topology{
+		{Segments: map[string]string{TopologyKeyNode: hp.nodeID}},
+	}
 
 	// Need to check for already existing volume name, and if found
 	// check for the requested capacity and already allocated capacity

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -62,23 +62,28 @@ type hostPath struct {
 	// gRPC calls involving any of the fields below must be serialized
 	// by locking this mutex before starting. Internal helper
 	// functions assume that the mutex has been locked.
-	mutex     sync.Mutex
-	volumes   map[string]hostPathVolume
-	snapshots map[string]hostPathSnapshot
-	capacity  Capacity
+	mutex        sync.Mutex
+	volumes      map[string]hostPathVolume
+	snapshots    map[string]hostPathSnapshot
+	capacity     Capacity
+	enableAttach bool
 }
 
 type hostPathVolume struct {
-	VolName       string     `json:"volName"`
-	VolID         string     `json:"volID"`
-	VolSize       int64      `json:"volSize"`
-	VolPath       string     `json:"volPath"`
-	VolAccessType accessType `json:"volAccessType"`
-	ParentVolID   string     `json:"parentVolID,omitempty"`
-	ParentSnapID  string     `json:"parentSnapID,omitempty"`
-	Ephemeral     bool       `json:"ephemeral"`
-	NodeID        string     `json:"nodeID"`
-	Kind          string     `json:"kind"`
+	VolName        string     `json:"volName"`
+	VolID          string     `json:"volID"`
+	VolSize        int64      `json:"volSize"`
+	VolPath        string     `json:"volPath"`
+	VolAccessType  accessType `json:"volAccessType"`
+	ParentVolID    string     `json:"parentVolID,omitempty"`
+	ParentSnapID   string     `json:"parentSnapID,omitempty"`
+	Ephemeral      bool       `json:"ephemeral"`
+	NodeID         string     `json:"nodeID"`
+	Kind           string     `json:"kind"`
+	ReadOnlyAttach bool       `json:"readOnlyAttach"`
+	IsAttached     bool       `json:"isAttached"`
+	IsStaged       bool       `json:"isStaged"`
+	IsPublished    bool       `json:"isPublished"`
 }
 
 type hostPathSnapshot struct {
@@ -105,7 +110,7 @@ const (
 	snapshotExt = ".snap"
 )
 
-func NewHostPathDriver(driverName, nodeID, endpoint string, ephemeral bool, maxVolumesPerNode int64, version string, capacity Capacity) (*hostPath, error) {
+func NewHostPathDriver(driverName, nodeID, endpoint string, ephemeral bool, maxVolumesPerNode int64, version string, capacity Capacity, enableAttach bool) (*hostPath, error) {
 	if driverName == "" {
 		return nil, errors.New("no driver name provided")
 	}
@@ -136,6 +141,7 @@ func NewHostPathDriver(driverName, nodeID, endpoint string, ephemeral bool, maxV
 		ephemeral:         ephemeral,
 		maxVolumesPerNode: maxVolumesPerNode,
 		capacity:          capacity,
+		enableAttach:      enableAttach,
 
 		volumes:   map[string]hostPathVolume{},
 		snapshots: map[string]hostPathSnapshot{},

--- a/pkg/hostpath/server.go
+++ b/pkg/hostpath/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hostpath
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -114,16 +115,68 @@ func parseEndpoint(ep string) (string, string, error) {
 }
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	pri := glog.Level(3)
 	if info.FullMethod == "/csi.v1.Identity/Probe" {
-		return handler(ctx, req)
+		// This call occurs frequently, therefore it only gets log at level 5.
+		pri = 5
 	}
-	glog.V(3).Infof("GRPC call: %s", info.FullMethod)
-	glog.V(5).Infof("GRPC request: %+v", protosanitizer.StripSecrets(req))
+	glog.V(pri).Infof("GRPC call: %s", info.FullMethod)
+
+	v5 := glog.V(5)
+	if v5 {
+		v5.Infof("GRPC request: %s", protosanitizer.StripSecrets(req))
+	}
 	resp, err := handler(ctx, req)
 	if err != nil {
+		// Always log errors. Probably not useful though without the method name?!
 		glog.Errorf("GRPC error: %v", err)
-	} else {
-		glog.V(5).Infof("GRPC response: %+v", protosanitizer.StripSecrets(resp))
 	}
+
+	if v5 {
+		v5.Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
+
+		// In JSON format, intentionally logging without stripping secret
+		// fields due to below reasons:
+		// - It's technically complicated because protosanitizer.StripSecrets does
+		//   not construct new objects, it just wraps the existing ones with a custom
+		//   String implementation. Therefore a simple json.Marshal(protosanitizer.StripSecrets(resp))
+		//   will still include secrets because it reads fields directly
+		//   and more complicated code would be needed.
+		// - This is indeed for verification in mock e2e tests. though
+		//   currently no test which look at secrets, but we might.
+		//   so conceptually it seems better to me to include secrets.
+		logGRPCJson(info.FullMethod, req, resp, err)
+	}
+
 	return resp, err
+}
+
+// logGRPCJson logs the called GRPC call details in JSON format
+func logGRPCJson(method string, request, reply interface{}, err error) {
+	// Log JSON with the request and response for easier parsing
+	logMessage := struct {
+		Method   string
+		Request  interface{}
+		Response interface{}
+		// Error as string, for backward compatibility.
+		// "" on no error.
+		Error string
+		// Full error dump, to be able to parse out full gRPC error code and message separately in a test.
+		FullError error
+	}{
+		Method:    method,
+		Request:   request,
+		Response:  reply,
+		FullError: err,
+	}
+
+	if err != nil {
+		logMessage.Error = err.Error()
+	}
+
+	msg, err := json.Marshal(logMessage)
+	if err != nil {
+		logMessage.Error = err.Error()
+	}
+	glog.V(5).Infof("gRPCCall: %s\n", msg)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This the first step towards the goal of  replacing the Mock CSI driver with host-path driver in Kubernetes E2E testing as described in #247 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Added 'proxy' support; where the host-path driver offloads the CSI requests transparently to the external CSI driver running at `--proxy-endpoint`.
- Implemented Controller{Publish,Unpublish}Volume calls. Introduced a new command-line argument `--enable-attach` (defaults to `false`) which controls if the driver should add `RPC_PUBLISH_UNPUBLISH_VOLUME` to its controller capablilities.
- GRPC calls are logged in a unified(request, reply, and error) JSON format.
```