### PR TITLE
storage capacity e2e test

### DIFF
--- a/deploy/kubernetes-distributed/deploy.sh
+++ b/deploy/kubernetes-distributed/deploy.sh
@@ -233,5 +233,5 @@ fi
 # Create a test driver configuration in the place where the prow job
 # expects it?
 if [ "${CSI_PROW_TEST_DRIVER}" ]; then
-    cp "${BASE_DIR}/test-driver.yaml" "${CSI_PROW_TEST_DRIVER}"
+    sed -e "s/capacity: true/capacity: ${have_csistoragecapacity}/" >"${BASE_DIR}/test-driver.yaml" "${CSI_PROW_TEST_DRIVER}"
 fi

--- a/deploy/kubernetes-distributed/test-driver.yaml
+++ b/deploy/kubernetes-distributed/test-driver.yaml
@@ -16,5 +16,8 @@ DriverInfo:
     persistence: true
     singleNodeVolume: true
     topology: true
+    capacity: true # will be adapted by deploy.sh based on cluster support for CSIStorageCapacity
+  TopologyKeys:
+  - topology.hostpath.csi/node
 InlineVolumes:
 - shared: true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This enables testing CSIStorageCapacity publishing if https://github.com/kubernetes/kubernetes/pull/100537 gets merged.

**Does this PR introduce a user-facing change?**:
```release-note
Testing of CSIStorageCapacity publishing with https://github.com/kubernetes/kubernetes/pull/100537 is enabled.
```
