### PR TITLE
deploy: update external-provisioner to v2.1.1

### DIFF
--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-provisioner.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This brings in some bug fixes:

- External-provisioner may have stopped provisioning for a PVC depending on certain timing conditions (provisioning failed once, next attempt currently running, PVC update arrives from API server).
- Fix CSI translation issues with EBS, AzureFile and Cinder drivers
- Producing storage capacity may have failed with the object has been modified errors
- Fix topology translation during CSI migration for gce-pd, aws-ebs, cinder drivers

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
updated external-provisioner from v2.1.0 to v2.1.1 to include some bug fixes
```
