### PR TITLE
Add more missing features from mock csi driver

### DIFF
--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -53,6 +53,7 @@ func main() {
 	flag.BoolVar(&cfg.EnableAttach, "enable-attach", false, "Enables RPC_PUBLISH_UNPUBLISH_VOLUME capability.")
 	flag.Int64Var(&cfg.MaxVolumeSize, "max-volume-size", 1024*1024*1024*1024, "maximum size of volumes in bytes (inclusive)")
 	flag.BoolVar(&cfg.EnableTopology, "enable-topology", true, "Enables PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS capability.")
+	flag.BoolVar(&cfg.EnableVolumeExpansion, "node-expand-required", true, "Enables NodeServiceCapability_RPC_EXPAND_VOLUME capacity.")
 	showVersion := flag.Bool("version", false, "Show version.")
 	// The proxy-endpoint option is intended to used by the Kubernetes E2E test suite
 	// for proxying incoming calls to the embedded mock CSI driver.

--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -54,6 +54,7 @@ func main() {
 	flag.Int64Var(&cfg.MaxVolumeSize, "max-volume-size", 1024*1024*1024*1024, "maximum size of volumes in bytes (inclusive)")
 	flag.BoolVar(&cfg.EnableTopology, "enable-topology", true, "Enables PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS capability.")
 	flag.BoolVar(&cfg.EnableVolumeExpansion, "node-expand-required", true, "Enables NodeServiceCapability_RPC_EXPAND_VOLUME capacity.")
+	flag.Int64Var(&cfg.AttachLimit, "attach-limit", 0, "Maximum number of attachable volumes on a node. Zero refers to no limit.")
 	showVersion := flag.Bool("version", false, "Show version.")
 	// The proxy-endpoint option is intended to used by the Kubernetes E2E test suite
 	// for proxying incoming calls to the embedded mock CSI driver.

--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -52,7 +52,7 @@ func main() {
 	flag.Var(&cfg.Capacity, "capacity", "Simulate storage capacity. The parameter is <kind>=<quantity> where <kind> is the value of a 'kind' storage class parameter and <quantity> is the total amount of bytes for that kind. The flag may be used multiple times to configure different kinds.")
 	flag.BoolVar(&cfg.EnableAttach, "enable-attach", false, "Enables RPC_PUBLISH_UNPUBLISH_VOLUME capability.")
 	flag.Int64Var(&cfg.MaxVolumeSize, "max-volume-size", 1024*1024*1024*1024, "maximum size of volumes in bytes (inclusive)")
-
+	flag.BoolVar(&cfg.EnableTopology, "enable-topology", true, "Enables PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS capability.")
 	showVersion := flag.Bool("version", false, "Show version.")
 	// The proxy-endpoint option is intended to used by the Kubernetes E2E test suite
 	// for proxying incoming calls to the embedded mock CSI driver.

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -696,6 +696,9 @@ func (hp *hostPath) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReq
 }
 
 func (hp *hostPath) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+	if !hp.config.EnableVolumeExpansion {
+		return nil, status.Error(codes.Unimplemented, "ControllerExpandVolume is not supported")
+	}
 
 	volID := req.GetVolumeId()
 	if len(volID) == 0 {
@@ -779,8 +782,10 @@ func (hp *hostPath) getControllerServiceCapabilities() []*csi.ControllerServiceC
 			csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
-			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 			csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
+		}
+		if hp.config.EnableVolumeExpansion {
+			cl = append(cl, csi.ControllerServiceCapability_RPC_EXPAND_VOLUME)
 		}
 		if hp.config.EnableAttach {
 			cl = append(cl, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -99,8 +99,9 @@ func (hp *hostPath) CreateVolume(ctx context.Context, req *csi.CreateVolumeReque
 	defer hp.mutex.Unlock()
 
 	capacity := int64(req.GetCapacityRange().GetRequiredBytes())
-	topologies := []*csi.Topology{
-		{Segments: map[string]string{TopologyKeyNode: hp.config.NodeID}},
+	topologies := []*csi.Topology{}
+	if hp.config.EnableTopology {
+		topologies = append(topologies, &csi.Topology{Segments: map[string]string{TopologyKeyNode: hp.config.NodeID}})
 	}
 
 	// Need to check for already existing volume name, and if found

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -304,6 +304,11 @@ func (hp *hostPath) ControllerPublishVolume(ctx context.Context, req *csi.Contro
 		}, nil
 	}
 
+	// Check attach limit before publishing.
+	if hp.config.AttachLimit > 0 && hp.getAttachCount() >= hp.config.AttachLimit {
+		return nil, status.Errorf(codes.ResourceExhausted, "Cannot attach any more volumes to this node ('%s')", hp.config.NodeID)
+	}
+
 	vol.IsAttached = true
 	vol.ReadOnlyAttach = req.GetReadonly()
 	if err := hp.updateVolume(vol.VolID, vol); err != nil {

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -423,7 +423,7 @@ func (hp *hostPath) loadFromSnapshot(size int64, snapshotId, destPath string, mo
 	if !ok {
 		return status.Errorf(codes.NotFound, "cannot find snapshot %v", snapshotId)
 	}
-	if snapshot.ReadyToUse != true {
+	if !snapshot.ReadyToUse {
 		return fmt.Errorf("snapshot %v is not yet ready to use", snapshotId)
 	}
 	if snapshot.SizeBytes > size {

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -98,6 +98,7 @@ type Config struct {
 	VendorVersion         string
 	MaxVolumesPerNode     int64
 	MaxVolumeSize         int64
+	AttachLimit           int64
 	Capacity              Capacity
 	Ephemeral             bool
 	ShowVersion           bool
@@ -516,6 +517,16 @@ func (hp *hostPath) getSortedVolumeIDs() []string {
 
 	sort.Strings(ids)
 	return ids
+}
+
+func (hp *hostPath) getAttachCount() int64 {
+	count := int64(0)
+	for _, vol := range hp.volumes {
+		if vol.IsAttached {
+			count++
+		}
+	}
+	return count
 }
 
 func filterVolumeName(targetPath string) string {

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -102,6 +102,7 @@ type Config struct {
 	Ephemeral         bool
 	ShowVersion       bool
 	EnableAttach      bool
+	EnableTopology    bool
 }
 
 var (

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -91,18 +91,19 @@ type hostPathSnapshot struct {
 }
 
 type Config struct {
-	DriverName        string
-	Endpoint          string
-	ProxyEndpoint     string
-	NodeID            string
-	VendorVersion     string
-	MaxVolumesPerNode int64
-	MaxVolumeSize     int64
-	Capacity          Capacity
-	Ephemeral         bool
-	ShowVersion       bool
-	EnableAttach      bool
-	EnableTopology    bool
+	DriverName            string
+	Endpoint              string
+	ProxyEndpoint         string
+	NodeID                string
+	VendorVersion         string
+	MaxVolumesPerNode     int64
+	MaxVolumeSize         int64
+	Capacity              Capacity
+	Ephemeral             bool
+	ShowVersion           bool
+	EnableAttach          bool
+	EnableTopology        bool
+	EnableVolumeExpansion bool
 }
 
 var (

--- a/pkg/hostpath/identityserver.go
+++ b/pkg/hostpath/identityserver.go
@@ -47,22 +47,24 @@ func (hp *hostPath) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.Prob
 
 func (hp *hostPath) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	glog.V(5).Infof("Using default capabilities")
-	return &csi.GetPluginCapabilitiesResponse{
-		Capabilities: []*csi.PluginCapability{
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
-					},
+	caps := []*csi.PluginCapability{
+		{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
 				},
 			},
 		},
-	}, nil
+	}
+	if hp.config.EnableTopology {
+		caps = append(caps, &csi.PluginCapability{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+				},
+			},
+		})
+	}
+
+	return &csi.GetPluginCapabilitiesResponse{Capabilities: caps}, nil
 }

--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -302,16 +302,18 @@ func (hp *hostPath) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageV
 }
 
 func (hp *hostPath) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-
-	topology := &csi.Topology{
-		Segments: map[string]string{TopologyKeyNode: hp.config.NodeID},
+	resp := &csi.NodeGetInfoResponse{
+		NodeId:            hp.config.NodeID,
+		MaxVolumesPerNode: hp.config.MaxVolumesPerNode,
 	}
 
-	return &csi.NodeGetInfoResponse{
-		NodeId:             hp.config.NodeID,
-		MaxVolumesPerNode:  hp.config.MaxVolumesPerNode,
-		AccessibleTopology: topology,
-	}, nil
+	if hp.config.EnableTopology {
+		resp.AccessibleTopology = &csi.Topology{
+			Segments: map[string]string{TopologyKeyNode: hp.config.NodeID},
+		}
+	}
+
+	return resp, nil
 }
 
 func (hp *hostPath) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {

--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -313,6 +313,10 @@ func (hp *hostPath) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest
 		}
 	}
 
+	if hp.config.AttachLimit > 0 {
+		resp.MaxVolumesPerNode = hp.config.AttachLimit
+	}
+
 	return resp, nil
 }
 

--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -317,38 +317,40 @@ func (hp *hostPath) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest
 }
 
 func (hp *hostPath) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-
-	return &csi.NodeGetCapabilitiesResponse{
-		Capabilities: []*csi.NodeServiceCapability{
-			{
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
-					},
-				},
-			},
-			{
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
-					},
-				},
-			},
-			{
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
-					},
-				},
-			}, {
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
-					},
+	caps := []*csi.NodeServiceCapability{
+		{
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 				},
 			},
 		},
-	}, nil
+		{
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+				},
+			},
+		},
+		{
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+				},
+			},
+		},
+	}
+	if hp.config.EnableVolumeExpansion {
+		caps = append(caps, &csi.NodeServiceCapability{
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+				},
+			},
+		})
+	}
+
+	return &csi.NodeGetCapabilitiesResponse{Capabilities: caps}, nil
 }
 
 func (hp *hostPath) NodeGetVolumeStats(ctx context.Context, in *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
@@ -405,6 +407,9 @@ func (hp *hostPath) NodeGetVolumeStats(ctx context.Context, in *csi.NodeGetVolum
 
 // NodeExpandVolume is only implemented so the driver can be used for e2e testing.
 func (hp *hostPath) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+	if !hp.config.EnableVolumeExpansion {
+		return nil, status.Error(codes.Unimplemented, "NodeExpandVolume is not supported")
+	}
 
 	volID := req.GetVolumeId()
 	if len(volID) == 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
With the combination of #260,  this enables in replacing the Mock CSI driver with host-path driver in Kubernetes E2E testing as described in #247.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This PR is based on changes in #260.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

* Added support for configuring the maximum number of volumes that could be attached on a node using `--attach-limit`.
* New command-line option `--enable-topology` for enabling/disabling driver topology.
* New command-line option `--node-expand-required` for enabling/disabling volume expansion feature.

```
