### PR TITLE
deploy: release v1.6.2 with v1.6.2 images in YAML files

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -1,6 +1,15 @@
-# Release notes for v1.6.1
+# Release notes for v1.6.2
 
 [Documentation](https://kubernetes-csi.github.io)
+
+# Changelog since v1.6.1
+
+## Changes by Kind
+
+### Bug or Regression
+ - The YAML files in v1.6.1 should have used the v1.6.1 image, but were still using v1.6.0. ([#266](https://github.com/kubernetes-csi/csi-driver-host-path/pull/266), [@pohly](https://github.com/pohly))
+
+# Release notes for v1.6.1
 
 # Changelog since v1.6.0
 

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
@@ -91,7 +91,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.6.0
+          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.6.2
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
@@ -91,7 +91,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.6.0
+          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.6.2
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -74,7 +74,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.6.0
+          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.6.2
           args:
             - --drivername=hostpath.csi.k8s.io
             - --v=5


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In csi-driver-host-path, YAML files must be updated to the
not-yet-released image before tagging a release. That was omitted
unintentionally when preparing v1.6.1.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
