### PR TITLE
service account name

### DIFF
--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
@@ -34,7 +34,7 @@ spec:
       labels:
         app: csi-hostpathplugin
     spec:
-      serviceAccount: csi-external-health-monitor-controller
+      serviceAccountName: csi-external-health-monitor-controller
       containers:
         - name: csi-external-health-monitor-agent
           image: k8s.gcr.io/sig-storage/csi-external-health-monitor-agent:v0.2.0

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-snapshotter.yaml
@@ -23,7 +23,7 @@ spec:
                 values:
                 - csi-hostpathplugin
             topologyKey: kubernetes.io/hostname
-      serviceAccount: csi-snapshotter
+      serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
           image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
@@ -34,7 +34,7 @@ spec:
       labels:
         app: csi-hostpathplugin
     spec:
-      serviceAccount: csi-external-health-monitor-controller
+      serviceAccountName: csi-external-health-monitor-controller
       containers:
         - name: csi-external-health-monitor-agent
           image: k8s.gcr.io/sig-storage/csi-external-health-monitor-agent:v0.2.0

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-snapshotter.yaml
@@ -23,7 +23,7 @@ spec:
                 values:
                 - csi-hostpathplugin
             topologyKey: kubernetes.io/hostname
-      serviceAccount: csi-snapshotter
+      serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
           image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -11,7 +11,7 @@ spec:
       labels:
         app: csi-hostpathplugin
     spec:
-      serviceAccount: csi-provisioner
+      serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The "serviceAccount" field was deprecated in favor of
"serviceAccountName". We should use the official field name.


**Does this PR introduce a user-facing change?**:
```release-note
Deployments use "serviceAccountName", the official name for the field, instead of the deprecated "serviceAccount" alias.
```
