### PR TITLE
Enable volume stats

### DIFF
--- a/pkg/hostpath/healthcheck.go
+++ b/pkg/hostpath/healthcheck.go
@@ -144,10 +144,8 @@ func (hp *hostPath) checkPVCapacityValid(volumeHandle string) (bool, error) {
 	return fscapacity >= volumeCapacity, nil
 }
 
-func getPVCapacity(volumeHandle string) (int64, int64, int64, error) {
-	sourcePath := getSourcePath(volumeHandle)
-	fsavailable, fscapacity, fsused, _, _, _, err := fs.FsInfo(sourcePath)
-	return fscapacity, fsused, fsavailable, err
+func getPVStats(volumePath string) (available int64, capacity int64, used int64, inodes int64, inodesFree int64, inodesUsed int64, err error) {
+	return fs.FsInfo(volumePath)
 }
 
 func checkPVUsage(volumeHandle string) (bool, error) {


### PR DESCRIPTION
Signed-off-by: stoneshi-yunify <stoneshi@yunify.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Without this PR, you can not get volume stats data provisioned by this driver

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #273 

**Special notes for your reviewer**:
Also return the inodes usage data, not sure why former code did not do that.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
User now can get volume stats data with Prometheus 
```
