### PR TITLE
deploy: use external-provisioner v2.2.0

### DIFF
--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-provisioner.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-provisioner.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Normal sidecar update. Relevant because of https://github.com/kubernetes-csi/csi-driver-host-path/issues/274

**Which issue(s) this PR fixes**:
Related-to https://github.com/kubernetes-csi/csi-driver-host-path/issues/274

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
update to external-provisioner v2.2.0
```
