### PR TITLE
deploy: replace /var/lib/kubelet on-the-fly

### DIFF
--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -30,6 +30,10 @@ BASE_DIR="$( cd "$( dirname "$0" )" && pwd )"
 TEMP_DIR="$( mktemp -d )"
 trap 'rm -rf ${TEMP_DIR}' EXIT
 
+# KUBELET_DATA_DIR can be set to replace the default /var/lib/kubelet.
+# All nodes must use the same directory.
+default_kubelet_data_dir=/var/lib/kubelet
+: ${KUBELET_DATA_DIR:=${default_kubelet_data_dir}}
 
 # If set, the following env variables override image registry and/or tag for each of the images.
 # They are named after the image name, with hyphen replaced by underscore and in upper case.
@@ -66,6 +70,7 @@ trap 'rm -rf ${TEMP_DIR}' EXIT
 # implies that refreshing that image has to be done manually.
 #
 # As a special case, 'none' as registry removes the registry name.
+
 
 # The default is to use the RBAC rules that match the image that is
 # being used, also in the case that the image gets overridden. This
@@ -196,7 +201,7 @@ done
 echo "deploying hostpath components"
 for i in $(ls ${BASE_DIR}/hostpath/*.yaml | sort); do
     echo "   $i"
-    modified="$(cat "$i" | while IFS= read -r line; do
+    modified="$(cat "$i" | sed -e "s;${default_kubelet_data_dir}/;${KUBELET_DATA_DIR}/;" | while IFS= read -r line; do
         nocomments="$(echo "$line" | sed -e 's/ *#.*$//')"
         if echo "$nocomments" | grep -q '^[[:space:]]*image:[[:space:]]*'; then
             # Split 'image: quay.io/k8scsi/csi-attacher:v1.0.1'


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This is useful for clusters where kubelet is installed
differently. KinD cluster testing might be done with a non-default
location to recognize and cleanup loop devices that were set up by
the driver.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-csi/csi-driver-host-path/issues/71

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
/var/lib/kubelet will be replaced on-the-fly by the deploy.sh scripts with the content of the KUBELET_DATA_DIR env variable.
```
