### PR TITLE
WIP: deploy with DaemonSet

### DIFF
--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
@@ -186,7 +186,11 @@ subjects:
 - kind: ServiceAccount
   name: csi-hostpathplugin-sa
 ---
-kind: StatefulSet
+# The driver gets deployed as a DaemonSet because that works better with "kubectl drain":
+# "kubectl drain --ignore-daemonsets" will keep the driver pods running while evicting
+# everything else. This is important because the driver pod is needed while shutting down
+# pods that use its volumes.
+kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpathplugin
@@ -196,11 +200,6 @@ metadata:
     app.kubernetes.io/name: csi-hostpathplugin
     app.kubernetes.io/component: plugin
 spec:
-  serviceName: "csi-hostpathplugin"
-  # One replica only:
-  # Host path driver only works when everything runs
-  # on a single node.
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: hostpath.csi.k8s.io
@@ -215,6 +214,10 @@ spec:
         app.kubernetes.io/name: csi-hostpathplugin
         app.kubernetes.io/component: plugin
     spec:
+      nodeSelector:
+        # This node name must be replaced with the actual name
+        # of the node on which the driver is supposed to run.
+        kubernetes.io/hostname: my-node-name
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

DaemonSet has the advantage that "kubectl drain --ignore-daemonsets"
keeps the driver pods running, which is required if normal pods on the
node are to be evicted. When using a StatefulSet, it can happen that
the driver pod gets evicted first and then the other pods cannot be
evicted because their volumes can no longer be unpublished and
unstaged.
    
The downside is that we still have to ensure that the driver only runs
on a single node. With DaemonSet, that is only possible by picking a
node in advance and using that node in a node selector. This node
selection tries to ensure that the pod can really run by checking
various conditions (node ready, network ready, no taints), but this is
less complete than the checks done by kube-scheduler (ignores load).

**Does this PR introduce a user-facing change?**:
```release-note
The non-distributed deployments use a DaemonSet to mimick best practices for CSI drivers. The driver still only runs on a single node which has to be chosen in advance based on various criteria (node ready, network ready, no taints) by the deploy script.
```
