### PR TITLE
volume lifecycle fixes

### DIFF
--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -368,7 +368,7 @@ func loadFromBlockVolume(hostPathVolume state.Volume, destPath string) error {
 func (hp *hostPath) getAttachCount() int64 {
 	count := int64(0)
 	for _, vol := range hp.state.GetVolumes() {
-		if vol.IsAttached {
+		if vol.Attached {
 			count++
 		}
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -48,9 +48,14 @@ type Volume struct {
 	NodeID         string
 	Kind           string
 	ReadOnlyAttach bool
-	IsAttached     bool
-	IsStaged       bool
-	IsPublished    bool
+	Attached       bool
+	// Staged contains the staging target path at which the volume
+	// was staged. A set of paths is used for consistency
+	// with Published.
+	Staged Strings
+	// Published contains the target paths where the volume
+	// was published.
+	Published Strings
 }
 
 type Snapshot struct {

--- a/pkg/state/strings.go
+++ b/pkg/state/strings.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+// Strings is an ordered set of strings with helper functions for
+// adding, searching and removing entries.
+type Strings []string
+
+// Add appends at the end.
+func (s *Strings) Add(str string) {
+	*s = append(*s, str)
+}
+
+// Has checks whether the string is already present.
+func (s *Strings) Has(str string) bool {
+	for _, str2 := range *s {
+		if str == str2 {
+			return true
+		}
+	}
+	return false
+}
+
+// Empty returns true if the list is empty.
+func (s *Strings) Empty() bool {
+	return len(*s) == 0
+}
+
+// Remove removes the first occurence of the string, if present.
+func (s *Strings) Remove(str string) {
+	for i, str2 := range *s {
+		if str == str2 {
+			*s = append((*s)[:i], (*s)[i+1:]...)
+			return
+		}
+	}
+}


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The [recently introduced support for tracking of staging and publishing](https://github.com/kubernetes-csi/csi-driver-host-path/pull/260) can be improved:
- Now it properly supports publishing more than once.
- Mutex locking in NodeStageVolume and NodeUnstageVolume was missing.
- NodeUnstageVolume and NodeUnpublishVolume can bail out early
      when nothing needs to be done. In the case of NodeUnpublishVolume
      that avoids unmounting at a path not managed by the driver. The
      driver cannot distinguish between an invalid path and an idempotent
      call, so this is not treated as an error.
- NodePublishVolume checks that the staging target path is valid.
- NodeStageVolume rejects staging more than once.


**Which issue(s) this PR fixes**:
Fixes #290 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
The code that gets enhanced was in no prior release, therefore we don't need to mention this change.
```release-note
NONE
```
