### PR TITLE
relax volume lifecycle checks by default

### DIFF
--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -52,6 +52,7 @@ func main() {
 	flag.Int64Var(&cfg.MaxVolumesPerNode, "maxvolumespernode", 0, "limit of volumes per node")
 	flag.Var(&cfg.Capacity, "capacity", "Simulate storage capacity. The parameter is <kind>=<quantity> where <kind> is the value of a 'kind' storage class parameter and <quantity> is the total amount of bytes for that kind. The flag may be used multiple times to configure different kinds.")
 	flag.BoolVar(&cfg.EnableAttach, "enable-attach", false, "Enables RPC_PUBLISH_UNPUBLISH_VOLUME capability.")
+	flag.BoolVar(&cfg.CheckVolumeLifecycle, "check-volume-lifecycle", false, "Can be used to turn some violations of the volume lifecycle into warnings instead of failing the incorrect gRPC call. Disabled by default because of https://github.com/kubernetes/kubernetes/issues/101911.")
 	flag.Int64Var(&cfg.MaxVolumeSize, "max-volume-size", 1024*1024*1024*1024, "maximum size of volumes in bytes (inclusive)")
 	flag.BoolVar(&cfg.EnableTopology, "enable-topology", true, "Enables PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS capability.")
 	flag.BoolVar(&cfg.EnableVolumeExpansion, "node-expand-required", true, "Enables NodeServiceCapability_RPC_EXPAND_VOLUME capacity.")

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	google.golang.org/genproto v0.0.0-20201209185603-f92720507ed4 // indirect
 	google.golang.org/grpc v1.34.0
 	k8s.io/apimachinery v0.21.0-alpha.0
+	k8s.io/klog/v2 v2.4.0
 	k8s.io/kubernetes v1.20.0
 	k8s.io/mount-utils v0.20.0 // indirect
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -74,6 +74,7 @@ type Config struct {
 	EnableAttach          bool
 	EnableTopology        bool
 	EnableVolumeExpansion bool
+	CheckVolumeLifecycle  bool
 }
 
 var (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -154,6 +154,7 @@ k8s.io/apiserver/pkg/util/feature
 # k8s.io/component-base v0.20.0 => k8s.io/component-base v0.20.0
 k8s.io/component-base/featuregate
 # k8s.io/klog/v2 v2.4.0
+## explicit
 k8s.io/klog/v2
 # k8s.io/kubernetes v1.20.0
 ## explicit


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:


The recently introduced "still in use" check revealed a bug in
Kubernetes (https://github.com/kubernetes/kubernetes/issues/101911). While
the check itself is correct, enabling it would cause a lot of test
flakes. Therefore the check has to be disabled until all Kubernetes
versions that we test against are fixed.

**Which issue(s) this PR fixes**:
Related-to https://github.com/kubernetes/kubernetes/issues/101911

**Does this PR introduce a user-facing change?**:
```release-note
Some violations of the volume lifecycle (specifically, VolumeDeleted without NodeUnpublishVolume+NodeUnstageVolume) are not fatal (the behavior in csi-driver-host-path <1.7) and merely cause a warning (new). --check-volume-lifecycle can be used to turn such violations into errors.
```
