### PR TITLE
deploy: bump sidecar images

### DIFF
--- a/deploy/kubernetes-1.18-test/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.18-test/hostpath/csi-hostpath-attacher.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.18-test/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.18-test/hostpath/csi-hostpath-plugin.yaml
@@ -77,7 +77,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
@@ -100,7 +100,7 @@ spec:
               mountPath: /csi
 
         - name: csi-external-health-monitor-controller
-          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.2.0
+          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -114,7 +114,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.18-test/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.18-test/hostpath/csi-hostpath-provisioner.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.18-test/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.18-test/hostpath/csi-hostpath-resizer.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.18/hostpath/csi-hostpath-plugin.yaml
@@ -277,7 +277,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-external-health-monitor-controller
-          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.2.0
+          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -291,7 +291,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -319,13 +319,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -339,7 +339,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -354,7 +354,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-attacher.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-plugin.yaml
@@ -77,7 +77,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
@@ -100,7 +100,7 @@ spec:
               mountPath: /csi
 
         - name: csi-external-health-monitor-controller
-          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.2.0
+          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -114,7 +114,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-provisioner.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-resizer.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.20-test/hostpath/csi-hostpath-snapshotter.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.20/hostpath/csi-hostpath-plugin.yaml
@@ -277,7 +277,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-external-health-monitor-controller
-          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.2.0
+          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -291,7 +291,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -319,13 +319,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -339,7 +339,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -354,7 +354,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
@@ -368,7 +368,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -60,7 +60,7 @@ spec:
               name: socket-dir
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -132,7 +132,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898

--- a/hack/bump-image-versions.sh
+++ b/hack/bump-image-versions.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will determine the latest release of all sidecars and
+# update to that version in *all* deployment files. Do not commit
+# everything! Sometimes sidecars must be locked on an older release
+# for older Kubernetes releases.
+
+set -e
+
+# List of images under https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage/GLOBAL
+images="
+csi-attacher
+csi-node-driver-registrar
+csi-provisioner
+csi-resizer
+csi-snapshotter
+csi-external-health-monitor-agent
+csi-external-health-monitor-controller
+livenessprobe
+"
+
+for image in $images; do
+    latest=$(gcloud container images list-tags k8s.gcr.io/sig-storage/$image --format='get(tags)' --filter='tags~^v AND NOT tags~v2020 AND NOT tags~-rc' --sort-by=tags | tail -n 1)
+
+    sed -i -e "s;\(image: k8s.gcr.io/sig-storage/$image:\).*;\1$latest;" $(find deploy -type f)
+done


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

A new script was used to automate the change. It was adapted from
k8s.gcr.io/images/k8s-staging-sig-storage/generate.sh, the script
which is used to promote images.

All changes were committed except for the version bump of the
csi-snapshotter in the 1.18 deployments.

**Does this PR introduce a user-facing change?**:
```release-note
Updated sidecar versions.
```
