### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -150,7 +150,7 @@ $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 	dockerfile_windows=$$(if [ -e ./cmd/$*/Dockerfile.Windows ]; then echo ./cmd/$*/Dockerfile.Windows; else echo Dockerfile.Windows; fi); \
 	if [ '$(BUILD_PLATFORMS)' ]; then build_platforms='$(BUILD_PLATFORMS)'; else build_platforms="linux amd64"; fi; \
 	if ! [ -f "$$dockerfile_windows" ]; then \
-		build_platforms="$$(echo "$$build_platforms" | sed -e 's/windows *[^ ]* *.exe *[^ ]* *[^ ]*//g' -e 's/; *;/;/g' -e 's/;[ ]*$//')"; \
+		build_platforms="$$(echo "$$build_platforms" | sed -e 's/windows *[^ ]* *.exe *[^ ]* *[^ ]*//g' -e 's/; *;/;/g' -e 's/;[ ]*$$//')"; \
 	fi; \
 	pushMultiArch () { \
 		tag=$$1; \


### PR DESCRIPTION
Squashed 'release-tools/' changes from 29bd39b3..ad83def4

[ad83def4](https://github.com/kubernetes-csi/csi-release-tools/commit/ad83def4) Merge [pull request #153](https://github.com/kubernetes-csi/csi-release-tools/pull/153) from pohly/fix-image-builds
[55617801](https://github.com/kubernetes-csi/csi-release-tools/commit/55617801) build.make: fix image publishng

git-subtree-dir: release-tools
git-subtree-split: ad83def420cb1027a0ab4b591aa5bdc05c1281a8

```release-note
Fixed image building.
```