### PR TITLE
deploy: fix kustomize issue when using sidecar files for rbac.yaml

### DIFF
--- a/deploy/kubernetes-distributed/deploy.sh
+++ b/deploy/kubernetes-distributed/deploy.sh
@@ -148,7 +148,10 @@ for component in CSI_PROVISIONER; do
     # we need to add the files locally in temp folder and using kustomize adding labels it will be applied
     if [[ "${current}" =~ ^http:// ]] || [[ "${current}" =~ ^https:// ]]; then
       run curl "${current}" --output "${TEMP_DIR}"/rbac.yaml --silent --location
-      current=./rbac.yaml
+    else
+        # Even for local files we need to copy because kustomize only supports files inside
+        # the root of a kustomization.
+        cp "${current}" "${TEMP_DIR}"/rbac.yaml
     fi
 
     cat <<- EOF > "${TEMP_DIR}"/kustomization.yaml
@@ -160,7 +163,7 @@ commonLabels:
   app.kubernetes.io/part-of: csi-driver-host-path
 
 resources:
-- ${current}
+- ./rbac.yaml
 EOF
 
     run kubectl apply --kustomize "${TEMP_DIR}"

--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -185,7 +185,10 @@ for component in CSI_PROVISIONER CSI_ATTACHER CSI_SNAPSHOTTER CSI_RESIZER CSI_EX
     # we need to add the files locally in temp folder and using kustomize adding labels it will be applied
     if [[ "${current}" =~ ^http:// ]] || [[ "${current}" =~ ^https:// ]]; then
       run curl "${current}" --output "${TEMP_DIR}"/rbac.yaml --silent --location
-      current=./rbac.yaml
+    else
+        # Even for local files we need to copy because kustomize only supports files inside
+        # the root of a kustomization.
+        cp "${current}" "${TEMP_DIR}"/rbac.yaml
     fi
 
     cat <<- EOF > "${TEMP_DIR}"/kustomization.yaml
@@ -197,7 +200,7 @@ commonLabels:
   app.kubernetes.io/part-of: csi-driver-host-path
 
 resources:
-- ${current}
+- ./rbac.yaml
 EOF
 
     run kubectl apply --kustomize "${TEMP_DIR}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Using kustomize to add labels to a sidecar's local rbac.yaml file
failed because although the file existed already, referencing it via
an absolute path was rejected by kustomize:

```
error: accumulating resources: accumulation err='accumulating resources from '/home/prow/go/src/github.com/kubernetes-csi/external-resizer/deploy/kubernetes/rbac.yaml': security; file '/home/prow/go/src/github.com/kubernetes-csi/external-resizer/deploy/kubernetes/rbac.yaml' is not in or below '/tmp/tmp.ehRnbHpnLX'': new root '/home/prow/go/src/github.com/kubernetes-csi/external-resizer/deploy/kubernetes/rbac.yaml' cannot be absolute
```

**Does this PR introduce a user-facing change?**:
```release-note
The deploy scripts did not work when used to test sidecars because kustomize didn't allow rbac.yaml files with absolute paths.
```
