### PR TITLE
NodePublishVolume: require parents of target directory to exist

### DIFF
--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -141,7 +141,7 @@ func (hp *hostPath) NodePublishVolume(ctx context.Context, req *csi.NodePublishV
 		notMnt, err := mount.IsNotMountPoint(mount.New(""), targetPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				if err = os.MkdirAll(targetPath, 0750); err != nil {
+				if err = os.Mkdir(targetPath, 0750); err != nil {
 					return nil, fmt.Errorf("create target path: %w", err)
 				}
 				notMnt = true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

According to the spec, "the CO SHALL ensure that the parent directory
of this path exists". The driver didn't rely on that and created those
parent directories itself if necessary, without removing them in
NodeUnpublishVolume.

This hides potential bugs in the CO or incorrect configuration of
csi-sanity (like creating directories in the wrong pod). Therefore it
is better to be strict and only create the actual target directory
itself.

**Does this PR introduce a user-facing change?**:
```release-note
NodePublishVolume now requires that the CO creates the parents of the target directory, as implied by the CSI spec.
```
