### PR TITLE
UpdateSnapshot checks snapshot ID instead of VolID

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -244,7 +244,7 @@ func (s *state) GetSnapshots() []Snapshot {
 
 func (s *state) UpdateSnapshot(update Snapshot) error {
 	for i, snapshot := range s.Snapshots {
-		if snapshot.VolID == update.VolID {
+		if snapshot.Id == update.Id {
 			s.Snapshots[i] = update
 			return s.dump()
 		}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -88,3 +88,39 @@ func TestSnapshots(t *testing.T) {
 
 	require.Empty(t, s.GetSnapshots(), "final snapshots")
 }
+
+// TestSnapshotsFromSameSource tests that multiple snapshots from the same
+// source can exist at the same time.
+func TestSnapshotsFromSameSource(t *testing.T) {
+	tmp := t.TempDir()
+	statefileName := path.Join(tmp, "state.json")
+
+	s, err := New(statefileName)
+	require.NoError(t, err, "construct state")
+
+	err = s.UpdateSnapshot(Snapshot{Id: "foo", Name: "foo-name", VolID: "source"})
+	require.NoError(t, err, "add snapshot")
+	err = s.UpdateSnapshot(Snapshot{Id: "bar", Name: "bar-name", VolID: "source"})
+	require.NoError(t, err, "add snapshot")
+
+	_, err = s.GetSnapshotByID("foo")
+	require.NoError(t, err, "get existing snapshot by ID 'foo'")
+	_, err = s.GetSnapshotByName("foo-name")
+	require.NoError(t, err, "get existing snapshot by name 'foo-name'")
+	_, err = s.GetSnapshotByID("bar")
+	require.NoError(t, err, "get existing snapshot by ID 'bar'")
+	_, err = s.GetSnapshotByName("bar-name")
+	require.NoError(t, err, "get existing snapshot by name 'bar-name'")
+
+	// Make sure it still works after reconstruction
+	s, err = New(statefileName)
+	require.NoError(t, err, "reconstruct state")
+	_, err = s.GetSnapshotByID("foo")
+	require.NoError(t, err, "get existing snapshot by ID 'foo'")
+	_, err = s.GetSnapshotByName("foo-name")
+	require.NoError(t, err, "get existing snapshot by name 'foo-name'")
+	_, err = s.GetSnapshotByID("bar")
+	require.NoError(t, err, "get existing snapshot by ID 'bar'")
+	_, err = s.GetSnapshotByName("bar-name")
+	require.NoError(t, err, "get existing snapshot by name 'bar-name'")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**: Fixes a bug where a second snapshot from a PVC source overwrites the first snapshot.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
