### PR TITLE
Fix build on 32bit

### DIFF
--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -653,6 +653,7 @@ func (hp *hostPath) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReq
 		ulenSnapshots = int32(len(snapshots))
 		maxEntries    = req.MaxEntries
 		startingToken int32
+		maxToken      = uint32(math.MaxUint32)
 	)
 
 	if v := req.StartingToken; v != "" {
@@ -661,7 +662,7 @@ func (hp *hostPath) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReq
 			return nil, status.Errorf(
 				codes.Aborted,
 				"startingToken=%d !< int32=%d",
-				startingToken, math.MaxUint32)
+				startingToken, maxToken)
 		}
 		startingToken = int32(i)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The constant math.MaxUint32 has no type specified. Golang tries to cast
it to int, which crashes the assembly on 32 bit architectures.

Steps to reproduce on the current master: 
```
$ GOARCH=386 go build ./cmd/hostpathplugin/main.go
# github.com/kubernetes-csi/csi-driver-host-path/pkg/hostpath
pkg/hostpath/controllerserver.go:663:5: constant 4294967295 overflows int

$ GOARCH=arm go build ./cmd/hostpathplugin/main.go
# github.com/kubernetes-csi/csi-driver-host-path/pkg/hostpath
pkg/hostpath/controllerserver.go:663:5: constant 4294967295 overflows int
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes-csi/csi-release-tools#167

**Special notes for your reviewer**:

I want to get a build of images for armv7 architecture. This change should fix the build of this PR kubernetes-csi/node-driver-registrar#161 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix build on 32bit platforms
```
