### PR TITLE
resource exhausted fix

### DIFF
--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -139,7 +139,7 @@ func (hp *hostPath) CreateVolume(ctx context.Context, req *csi.CreateVolumeReque
 	kind := req.GetParameters()[storageKind]
 	vol, err := hp.createVolume(volumeID, req.GetName(), capacity, requestedAccessType, false /* ephemeral */, kind)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create volume %v: %w", volumeID, err)
+		return nil, err
 	}
 	glog.V(4).Infof("created volume %s at path %s", vol.VolID, vol.VolPath)
 

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -157,13 +157,12 @@ func (hp *hostPath) createVolume(volID, name string, cap int64, volAccessType st
 		}
 		if kind == "" {
 			// Still nothing?!
-			return nil, status.Errorf(codes.OutOfRange, "requested capacity %d of arbitrary storage exceeds all remaining capacity", cap)
+			return nil, status.Errorf(codes.ResourceExhausted, "requested capacity %d of arbitrary storage exceeds all remaining capacity", cap)
 		}
 		used := hp.sumVolumeSizes(kind)
 		available := hp.config.Capacity[kind]
 		if used+cap > available.Value() {
-
-			return nil, status.Errorf(codes.OutOfRange, "requested capacity %d exceeds remaining capacity for %q, %s out of %s already used",
+			return nil, status.Errorf(codes.ResourceExhausted, "requested capacity %d exceeds remaining capacity for %q, %s out of %s already used",
 				cap, kind, resource.NewQuantity(used, resource.BinarySI).String(), available.String())
 		}
 	} else if kind != "" {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The driver must return ResourceExhausted when it doesn't have capacity, not
OutOfRange. Then external-provisioner knows that it needs to cause
rescheduling.

**Special notes for your reviewer**:

This bug was introduced in 6ad318936 via cut-and-paste. For the case above
where the volume is too large for *all* driver instances because it exceeds the
configured maximum volume size it makes sense to return OutOfRange because the
error is permanent.

**Does this PR introduce a user-facing change?**:
```release-note
fix rescheduling with distributed provisioning when simulated storage capacity is exhausted
```
