### PR TITLE
Add storage capacity exhausted error fix to 1.7.3 release notes

### DIFF
--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -9,6 +9,7 @@
 ### Bug or Regression
 
 - Fix build on 32bit platforms ([#320](https://github.com/kubernetes-csi/csi-driver-host-path/pull/320), [@c0va23](https://github.com/c0va23))
+- Fix rescheduling with distributed provisioning when simulated storage capacity is exhausted ([#331](https://github.com/kubernetes-csi/csi-driver-host-path/pull/331), [@pohly](https://github.com/pohly))
 - Fixed bug where `UpdateSnapshot` checks the volume ID when it should check the snapshot ID before updating. ([#315](https://github.com/kubernetes-csi/csi-driver-host-path/pull/315), [@verult](https://github.com/verult))
 
 ### Other (Cleanup or Flake)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**: Preparing for 1.7.3 release

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

/assign @pohly 