### PR TITLE
Update csi-snapshotter images to v5.0.1

### DIFF
--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-snapshotter.yaml
@@ -37,9 +37,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          # TODO GG: Replace w/ v5.0.0 once released
-          # https://github.com/kubernetes-csi/external-snapshotter/issues/610
-          image: gcr.io/k8s-staging-sig-storage/csi-snapshotter:v5.0.0-rc1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.21/hostpath/csi-hostpath-plugin.yaml
@@ -352,9 +352,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          # TODO GG: Replace w/ v5.0.0 once released
-          # https://github.com/kubernetes-csi/external-snapshotter/issues/610
-          image: gcr.io/k8s-staging-sig-storage/csi-snapshotter:v5.0.0-rc1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Followup to https://github.com/kubernetes-csi/csi-driver-host-path/pull/342#issuecomment-1036346149.

I had to change the image registry to `k8s.gcr.io/sig-storage` so [the script would pick it up](https://github.com/kubernetes-csi/csi-driver-host-path/blob/v1.7.3/hack/bump-image-versions.sh#L39).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

@pohly @xing-yang 