### PR TITLE
Fix KUBERNETES_CSI_OWNERS_ALIASES file for emeritus_approver and emeritus_reviewer

### DIFF
--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -31,15 +31,15 @@ aliases:
 
 # This documents who previously contributed to Kubernetes-CSI
 # as approver.
-emeritus_approver:
+emeritus_approvers:
 - lpabon
 - sbezverk
 - vladimirvivien
 
 # This documents who previously contributed to Kubernetes-CSI
 # as reviewer.
-emeritus_reviewer:
-- lpabon
-- saad-ali
-- sbezverk
-- vladimirvivien
+# emeritus_reviewer:
+# - lpabon
+# - saad-ali
+# - sbezverk
+# - vladimirvivien


### PR DESCRIPTION
Fix KUBERNETES_CSI_OWNERS_ALIASES file for emeritus_approver and emeritus_reviewer

Change emeritus_approver to emeritus_approvers and remove emeritus_reviewer

Signed-off-by: Srinivas Pokala <Pokala.Srinivas@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it:**
This PR fixes the KUBERNETES_CSI_OWNERS_ALIASES  file

**What type of PR is this?**
/kind cleanup


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/community/issues/6334
