### PR TITLE
Move from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-attacher.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-plugin.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: csi-external-health-monitor-controller
       containers:
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.7.3
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -77,13 +77,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-external-health-monitor-controller
-          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.4.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.4.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -97,7 +97,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-provisioner.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-resizer.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-snapshotter.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.21/hostpath/csi-hostpath-plugin.yaml
@@ -218,7 +218,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.7.3
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -261,7 +261,7 @@ spec:
               name: dev-dir
 
         - name: csi-external-health-monitor-controller
-          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.4.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.4.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -275,7 +275,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -303,13 +303,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -323,7 +323,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -338,7 +338,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
@@ -352,7 +352,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-distributed/app-generic-ephemeral.yaml
+++ b/deploy/kubernetes-distributed/app-generic-ephemeral.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: my-frontend
-      image: k8s.gcr.io/pause
+      image: registry.k8s.io/pause
       volumeMounts:
       - mountPath: "/data"
         name: my-csi-volume

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -60,7 +60,7 @@ spec:
               name: socket-dir
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -85,7 +85,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.7.3
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
           args:
             - --drivername=hostpath.csi.k8s.io
             - --v=5
@@ -132,7 +132,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898

--- a/hack/bump-image-versions.sh
+++ b/hack/bump-image-versions.sh
@@ -36,5 +36,5 @@ livenessprobe
 for image in $images; do
     latest=$(gcloud container images list-tags k8s.gcr.io/sig-storage/$image --format='get(tags)' --filter='tags~^v AND NOT tags~v2020 AND NOT tags~-rc' --sort-by=tags | tail -n 1)
 
-    sed -i -e "s;\(image: k8s.gcr.io/sig-storage/$image:\).*;\1$latest;" $(find deploy -type f)
+    sed -i -e "s;\(image: registry.k8s.io/sig-storage/$image:\).*;\1$latest;" $(find deploy -type f)
 done


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This updates the image registry in accordance with:

https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)
https://github.com/kubernetes/enhancements/pull/3079
https://github.com/kubernetes/kubernetes/pull/109938

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Move image references from k8s.gcr.io to registry.k8s.io
```
