### PR TITLE
make use of latest sidecar releases in the deployment

### DIFF
--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-attacher.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-plugin.yaml
@@ -77,13 +77,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-external-health-monitor-controller
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.4.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -97,7 +97,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-provisioner.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-resizer.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-snapshotter.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.21/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.21/hostpath/csi-hostpath-plugin.yaml
@@ -261,7 +261,7 @@ spec:
               name: dev-dir
 
         - name: csi-external-health-monitor-controller
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.4.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -275,7 +275,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -303,13 +303,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -323,7 +323,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -338,7 +338,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
@@ -352,7 +352,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -60,7 +60,7 @@ spec:
               name: socket-dir
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -132,7 +132,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind cleanup

```release-note
NONE
```

Additional Note for reviewer:
Good to have this sidecar update before the hostpath plugin release which has been referred/waited here (https://github.com/kubernetes-csi/external-snapshotter/pull/733)