### PR TITLE
Allow Kubernetes to change permission of provisioned volumes

### DIFF
--- a/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-driverinfo.yaml
+++ b/deploy/kubernetes-1.21-test/hostpath/csi-hostpath-driverinfo.yaml
@@ -15,3 +15,6 @@ spec:
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true
+  # Kubernetes may use fsGroup to change permissions and ownership 
+  # of the volume to match user requested fsGroup in the pod's SecurityPolicy
+  fsGroupPolicy: File

--- a/deploy/kubernetes-1.21/hostpath/csi-hostpath-driverinfo.yaml
+++ b/deploy/kubernetes-1.21/hostpath/csi-hostpath-driverinfo.yaml
@@ -15,3 +15,6 @@ spec:
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true
+  # Kubernetes may use fsGroup to change permissions and ownership 
+  # of the volume to match user requested fsGroup in the pod's SecurityPolicy
+  fsGroupPolicy: File

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-driverinfo.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-driverinfo.yaml
@@ -18,3 +18,6 @@ spec:
   # No attacher needed.
   attachRequired: false
   storageCapacity: true
+  # Kubernetes may use fsGroup to change permissions and ownership 
+  # of the volume to match user requested fsGroup in the pod's SecurityPolicy
+  fsGroupPolicy: File


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Allow Kubernetes to change permission of provisioned volumes. Offload permission change to Kubernetes:
https://github.com/kubernetes-csi/docs/blob/master/book/src/support-fsgroup.md

Description and detailed discussion is in #356 .

**Which issue(s) this PR fixes**:
Fixes #356 and https://github.com/kubernetes/minikube/issues/12360

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Set `fsGroupPolicy: File` to allow Kubernetes to set correct permissions for volumes with unprivileged container access

```
