### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/filter-junit.go
+++ b/release-tools/filter-junit.go
@@ -56,6 +56,7 @@ type TestCase struct {
 	Name      string     `xml:"name,attr"`
 	Time      string     `xml:"time,attr"`
 	SystemOut string     `xml:"system-out,omitempty"`
+	SystemErr string     `xml:"system-err,omitempty"`
 	Failure   string     `xml:"failure,omitempty"`
 	Skipped   SkipReason `xml:"skipped,omitempty"`
 }
@@ -109,7 +110,7 @@ func main() {
 			if err := xml.Unmarshal(data, &junitv2); err != nil {
 				panic(err)
 			}
-			junit = junitv2.TestSuite
+			junit.TestCases = append(junit.TestCases, junitv2.TestSuite.TestCases...)
 		}
 	}
 

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -1008,7 +1008,10 @@ run_e2e () (
     # the full Kubernetes E2E testsuite while only running a few tests.
     move_junit () {
         if ls "${ARTIFACTS}"/junit_[0-9]*.xml 2>/dev/null >/dev/null; then
-            run_filter_junit -t="External.Storage|CSI.mock.volume" -o "${ARTIFACTS}/junit_${name}.xml" "${ARTIFACTS}"/junit_[0-9]*.xml && rm -f "${ARTIFACTS}"/junit_[0-9]*.xml
+            mkdir -p "${ARTIFACTS}/junit/${name}" &&
+                mkdir -p "${ARTIFACTS}/junit/steps" &&
+                run_filter_junit -t="External.Storage|CSI.mock.volume" -o "${ARTIFACTS}/junit/steps/junit_${name}.xml" "${ARTIFACTS}"/junit_[0-9]*.xml &&
+                mv "${ARTIFACTS}"/junit_[0-9]*.xml "${ARTIFACTS}/junit/${name}/"
         fi
     }
     trap move_junit EXIT
@@ -1085,13 +1088,14 @@ kubectl exec "$pod" -c "${CSI_PROW_SANITY_CONTAINER}" -- /bin/sh -c "\${CHECK_PA
 EOF
 
     chmod u+x "${CSI_PROW_WORK}"/*dir_in_pod.sh
+    mkdir -p "${ARTIFACTS}/junit/steps"
 
     # This cannot run in parallel, because -csi.junitfile output
     # from different Ginkgo nodes would go to the same file. Also the
     # staging and target directories are the same.
     run_with_loggers "${CSI_PROW_WORK}/csi-sanity" \
                      -ginkgo.v \
-                     -csi.junitfile "${ARTIFACTS}/junit_sanity.xml" \
+                     -csi.junitfile "${ARTIFACTS}/junit/steps/junit_sanity.xml" \
                      -csi.endpoint "dns:///$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' csi-prow-control-plane):$(kubectl get "services/${CSI_PROW_SANITY_SERVICE}" -o "jsonpath={..nodePort}")" \
                      -csi.stagingdir "/tmp/staging" \
                      -csi.mountdir "/tmp/mount" \
@@ -1121,7 +1125,8 @@ make_test_to_junit () {
     # Plain make-test.xml was not delivered as text/xml by the web
     # server and ignored by spyglass. It seems that the name has to
     # match junit*.xml.
-    out="${ARTIFACTS}/junit_make_test.xml"
+    out="${ARTIFACTS}/junit/steps/junit_make_test.xml"
+    mkdir -p "$(dirname "$out")"
     testname=
     echo "<testsuite>" >>"$out"
 
@@ -1385,8 +1390,8 @@ main () {
     fi
 
     # Merge all junit files into one. This gets rid of duplicated "skipped" tests.
-    if ls "${ARTIFACTS}"/junit_*.xml 2>/dev/null >&2; then
-        run_filter_junit -o "${CSI_PROW_WORK}/junit_final.xml" "${ARTIFACTS}"/junit_*.xml && rm "${ARTIFACTS}"/junit_*.xml && mv "${CSI_PROW_WORK}/junit_final.xml" "${ARTIFACTS}"
+    if ls "${ARTIFACTS}"/junit/steps/junit_*.xml 2>/dev/null >&2; then
+        run_filter_junit -o "${ARTIFACTS}/junit_final.xml" "${ARTIFACTS}"/junit/steps/junit_*.xml
     fi
 
     return "$ret"


### PR DESCRIPTION
Squashed 'release-tools/' changes from 78c0fb71..b66c0824

[b66c0824](https://github.com/kubernetes-csi/csi-release-tools/commit/b66c0824) Merge [pull request #214](https://github.com/kubernetes-csi/csi-release-tools/pull/214) from pohly/junit-fixes
[b9b6763b](https://github.com/kubernetes-csi/csi-release-tools/commit/b9b6763b) filter-junit.go: fix loss of testcases when parsing Ginkgo v2 JUnit
[d4277839](https://github.com/kubernetes-csi/csi-release-tools/commit/d4277839) filter-junit.go: preserve system error log
[38e11468](https://github.com/kubernetes-csi/csi-release-tools/commit/38e11468) prow.sh: publish individual JUnit files as separate artifacts

git-subtree-dir: release-tools
git-subtree-split: b66c08249d4c33020bfbc473ad8d934fd1815b9f

```release-note
NONE
```