### PR TITLE
Add replace clause back to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,3 +43,57 @@ require (
 	k8s.io/component-base v0.26.0 // indirect
 	k8s.io/mount-utils v0.26.0 // indirect
 )
+
+replace k8s.io/api => k8s.io/api v0.26.0
+
+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.0
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.26.0
+
+replace k8s.io/apiserver => k8s.io/apiserver v0.26.0
+
+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.26.0
+
+replace k8s.io/client-go => k8s.io/client-go v0.26.0
+
+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.26.0
+
+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.26.0
+
+replace k8s.io/code-generator => k8s.io/code-generator v0.26.0
+
+replace k8s.io/component-base => k8s.io/component-base v0.26.0
+
+replace k8s.io/component-helpers => k8s.io/component-helpers v0.26.0
+
+replace k8s.io/controller-manager => k8s.io/controller-manager v0.26.0
+
+replace k8s.io/cri-api => k8s.io/cri-api v0.26.0
+
+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.0
+
+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.0
+
+replace k8s.io/kms => k8s.io/kms v0.26.0
+
+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.0
+
+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.0
+
+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.0
+
+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.26.0
+
+replace k8s.io/kubectl => k8s.io/kubectl v0.26.0
+
+replace k8s.io/kubelet => k8s.io/kubelet v0.26.0
+
+replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.26.0
+
+replace k8s.io/metrics => k8s.io/metrics v0.26.0
+
+replace k8s.io/mount-utils => k8s.io/mount-utils v0.26.0
+
+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.0
+
+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -191,7 +191,7 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# k8s.io/apimachinery v0.26.0
+# k8s.io/apimachinery v0.26.0 => k8s.io/apimachinery v0.26.0
 ## explicit; go 1.19
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/types
@@ -200,11 +200,11 @@ k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/version
-# k8s.io/apiserver v0.26.0
+# k8s.io/apiserver v0.26.0 => k8s.io/apiserver v0.26.0
 ## explicit; go 1.19
 k8s.io/apiserver/pkg/features
 k8s.io/apiserver/pkg/util/feature
-# k8s.io/component-base v0.26.0
+# k8s.io/component-base v0.26.0 => k8s.io/component-base v0.26.0
 ## explicit; go 1.19
 k8s.io/component-base/featuregate
 k8s.io/component-base/metrics
@@ -228,7 +228,7 @@ k8s.io/kubernetes/pkg/volume/util/fs
 k8s.io/kubernetes/pkg/volume/util/fsquota
 k8s.io/kubernetes/pkg/volume/util/fsquota/common
 k8s.io/kubernetes/pkg/volume/util/volumepathhandler
-# k8s.io/mount-utils v0.26.0
+# k8s.io/mount-utils v0.26.0 => k8s.io/mount-utils v0.26.0
 ## explicit; go 1.19
 k8s.io/mount-utils
 # k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
@@ -237,3 +237,30 @@ k8s.io/utils/exec
 k8s.io/utils/io
 k8s.io/utils/keymutex
 k8s.io/utils/mount
+# k8s.io/api => k8s.io/api v0.26.0
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.0
+# k8s.io/apimachinery => k8s.io/apimachinery v0.26.0
+# k8s.io/apiserver => k8s.io/apiserver v0.26.0
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.26.0
+# k8s.io/client-go => k8s.io/client-go v0.26.0
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.26.0
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.26.0
+# k8s.io/code-generator => k8s.io/code-generator v0.26.0
+# k8s.io/component-base => k8s.io/component-base v0.26.0
+# k8s.io/component-helpers => k8s.io/component-helpers v0.26.0
+# k8s.io/controller-manager => k8s.io/controller-manager v0.26.0
+# k8s.io/cri-api => k8s.io/cri-api v0.26.0
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.0
+# k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.0
+# k8s.io/kms => k8s.io/kms v0.26.0
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.0
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.0
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.0
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.26.0
+# k8s.io/kubectl => k8s.io/kubectl v0.26.0
+# k8s.io/kubelet => k8s.io/kubelet v0.26.0
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.26.0
+# k8s.io/metrics => k8s.io/metrics v0.26.0
+# k8s.io/mount-utils => k8s.io/mount-utils v0.26.0
+# k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.0
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.0


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds the "replace" clause back to go.mod.
Without the replace clause, "release-notes" tool has problem retrieving modules.

Run this command: `./release-tools/go-get-kubernetes.sh -p 1.26.0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
