### PR TITLE
Add `namespace: default` to Service and StatefulSets

### DIFF
--- a/deploy/kubernetes-1.24/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.24/hostpath/csi-hostpath-plugin.yaml
@@ -190,6 +190,7 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpathplugin
+  namespace: default
   labels:
     app.kubernetes.io/instance: hostpath.csi.k8s.io
     app.kubernetes.io/part-of: csi-driver-host-path

--- a/deploy/kubernetes-1.24/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.24/hostpath/csi-hostpath-testing.yaml
@@ -11,6 +11,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hostpath-service
+  namespace: default
   labels:
     app.kubernetes.io/instance: hostpath.csi.k8s.io
     app.kubernetes.io/part-of: csi-driver-host-path
@@ -30,6 +31,7 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-socat
+  namespace: default
   labels:
     app.kubernetes.io/instance: hostpath.csi.k8s.io
     app.kubernetes.io/part-of: csi-driver-host-path


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When the driver is deployed while the current context is set to something else than `default`, things go wrong as the Service and StatefulSets are created in the current namespace.

By adding the namespace explicitly in the Service and StatefulSets, all components of the driver get deployed correctly in the namespace called `default`.

**Which issue(s) this PR fixes**:

Fixes #397

**Special notes for your reviewer**:

The request in the linked issue was to be able to deploy in the current namespace when it was set with `kubectl config set-context --current --namespace=foo`. Other CSI drivers seem to use the `default` namespace too, so it seems cleaner to add `namespace: default` to the objects that don't have it yet.

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
