### PR TITLE
Update release tools

### DIFF
--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -17,7 +17,7 @@ The release manager must:
 Whenever a new Kubernetes minor version is released, our kubernetes-csi CI jobs
 must be updated.
 
-[Our CI jobs](https://k8s-testgrid.appspot.com/sig-storage-csi-ci) have the
+[Our CI jobs](https://testgrid.k8s.io/sig-storage-csi-ci) have the
 naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 
 1. Jobs should be actively monitored to find and fix failures in sidecars and
@@ -46,54 +46,45 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 ## Release Process
 1. Identify all issues and ongoing PRs that should go into the release, and
   drive them to resolution.
-1. Download the latest version of the
-   [K8s release notes generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
-1. Create a
-   [Github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-   with `repo:public_repo` access
-1. Generate release notes for the release. Replace arguments with the relevant
-   information.
-    * Clean up old cached information (also needed if you are generating release
-      notes for multiple repos)
-      ```bash
-      rm -rf /tmp/k8s-repo
-      ```
-    * For new minor releases on master:
-        ```bash
-        GITHUB_TOKEN=<token> release-notes \
-          --discover=mergebase-to-latest \
-          --org=kubernetes-csi \
-          --repo=external-provisioner \
-          --required-author="" \
-          --markdown-links \
-          --output out.md
-        ```
-    * For new patch releases on a release branch:
-        ```bash
-        GITHUB_TOKEN=<token> release-notes \
-          --discover=patch-to-latest \
-          --branch=release-1.1 \
-          --org=kubernetes-csi \
-          --repo=external-provisioner \
-          --required-author="" \
-          --markdown-links \
-          --output out.md
-        ```
-1. Compare the generated output to the new commits for the release to check if
-   any notable change missed a release note.
-1. Reword release notes as needed. Make sure to check notes for breaking
-   changes and deprecations.
-1. If release is a new major/minor version, create a new `CHANGELOG-<major>.<minor>.md`
-   file. Otherwise, add the release notes to the top of the existing CHANGELOG
-   file for that minor version.
-1. Submit a PR for the CHANGELOG changes.
-1. Submit a PR for README changes, in particular, Compatibility, Feature status,
-   and any other sections that may need updating.
 1. Check that all [canary CI
-  jobs](https://k8s-testgrid.appspot.com/sig-storage-csi-ci) are passing,
+  jobs](https://testgrid.k8s.io/sig-storage-csi-ci) are passing,
   and that test coverage is adequate for the changes that are going into the release.
 1. Check that the post-\<sidecar\>-push-images builds are succeeding.
-   [Example](https://k8s-testgrid.appspot.com/sig-storage-image-build#post-external-snapshotter-push-images)
+   [Example](https://testgrid.k8s.io/sig-storage-image-build#post-external-snapshotter-push-images)
+1. Generate release notes.
+    1.  Download the latest version of the [K8s release notes generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
+    1. Create a
+       [Github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+       with `repo:public_repo` access
+    1. For patch release, use the script generate_patch_release_notes.sh. Read the instructions at the top of the
+       script. The script also creates PRs for each branch.
+    1. For new minor releases, follow these steps and replace arguments with the relevant
+       information.
+        * Clean up old cached information (also needed if you are generating release
+          notes for multiple repos)
+          ```bash
+          rm -rf /tmp/k8s-repo
+          ```
+        * For new minor releases on master:
+            ```bash
+            GITHUB_TOKEN=<token> release-notes \
+              --discover=mergebase-to-latest \
+              --org=kubernetes-csi \
+              --repo=external-provisioner \
+              --required-author="" \
+              --markdown-links \
+              --output out.md
+            ```
+    1. Compare the generated output to the new commits for the release to check if
+       any notable change missed a release note.
+    1. Reword release notes as needed, ideally in the original PRs so that the
+       release notes can be regnerated. Make sure to check notes for breaking
+       changes and deprecations.
+    1. If release is a new major/minor version, create a new `CHANGELOG-<major>.<minor>.md`
+       file.
+    1. Submit a PR for the CHANGELOG changes.
+1. Submit a PR for README changes, in particular, Compatibility, Feature status,
+   and any other sections that may need updating.
 1. Make sure that no new PRs have merged in the meantime, and no PRs are in
    flight and soon to be merged.
 1. Create a new release following a previous release as a template. Be sure to select the correct
@@ -101,8 +92,8 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
    [external-provisioner example](https://github.com/kubernetes-csi/external-provisioner/releases/new)
 1. If release was a new major/minor version, create a new `release-<minor>`
    branch at that commit.
-1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
-1. Promote images from k8s-staging-sig-storage to k8s.gcr.io/sig-storage. From
+1. Check [image build status](https://testgrid.k8s.io/sig-storage-image-build).
+1. Promote images from k8s-staging-sig-storage to registry.k8s.io/sig-storage. From
    the [k8s image
    repo](https://github.com/kubernetes/k8s.io/tree/HEAD/registry.k8s.io/images/k8s-staging-sig-storage),
    run `./generate.sh > images.yaml`, and send a PR with the updated images.
@@ -120,7 +111,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 
 The following jobs are triggered after tagging to produce the corresponding
 image(s):
-https://k8s-testgrid.appspot.com/sig-storage-image-build
+https://testgrid.k8s.io/sig-storage-image-build
 
 Clicking on a failed build job opens that job in https://prow.k8s.io. Next to
 the job title is a rerun icon (circle with arrow). Clicking it opens a popup

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # See https://github.com/kubernetes/test-infra/blob/HEAD/config/jobs/image-pushing/README.md
 # for more details on image pushing process in Kubernetes.
 #
-# To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage.
+# To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/registry.k8s.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
 # Building three images in external-snapshotter takes more than an hour.
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20230424-910a2a439d'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20230623-56e06d7c18'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}

--- a/release-tools/contrib/get_supported_version_csi-sidecar.py
+++ b/release-tools/contrib/get_supported_version_csi-sidecar.py
@@ -1,0 +1,170 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import datetime
+import re
+from collections import defaultdict
+import subprocess
+import shutil
+from dateutil.relativedelta import relativedelta
+
+def check_gh_command():
+    """
+    Pretty much everything is processed from `gh`
+    Check that the `gh` command is in the path before anything else
+    """
+    if not shutil.which('gh'):
+        print("Error: The `gh` command is not available in the PATH.")
+        print("Please install the GitHub CLI (https://cli.github.com/) and try again.")
+        exit(1)
+
+def duration_ago(dt):
+    """
+    Humanize duration outputs
+    """
+    delta = relativedelta(datetime.datetime.now(), dt)
+    if delta.years > 0:
+        return f"{delta.years} year{'s' if delta.years > 1 else ''} ago"
+    elif delta.months > 0:
+        return f"{delta.months} month{'s' if delta.months > 1 else ''} ago"
+    elif delta.days > 0:
+        return f"{delta.days} day{'s' if delta.days > 1 else ''} ago"
+    elif delta.hours > 0:
+        return f"{delta.hours} hour{'s' if delta.hours > 1 else ''} ago"
+    elif delta.minutes > 0:
+        return f"{delta.minutes} minute{'s' if delta.minutes > 1 else ''} ago"
+    else:
+        return "just now"
+
+def parse_version(version):
+    """
+    Parse version assuming it is in the form of v1.2.3
+    """
+    pattern = r"v(\d+)\.(\d+)\.(\d+)"
+    match = re.match(pattern, version)
+    if match:
+        major, minor, patch =  map(int, match.groups())
+        return (major, minor, patch)
+
+def end_of_life_grouped_versions(versions):
+    """
+    Calculate the end of life date for a minor release version according to : https://kubernetes-csi.github.io/docs/project-policies.html#support
+
+    The input is an array of tuples of:
+      * grouped versions (e.g. 1.0, 1.1)
+      * array of that contains all versions and their release date (e.g. 1.0.0, 01-01-2013)
+
+    versions structure example :
+      [((3, 5), [('v3.5.0', datetime.datetime(2023, 4, 27, 22, 28, 6))]),
+       ((3, 4),
+       [('v3.4.1', datetime.datetime(2023, 4, 5, 17, 41, 15)),
+        ('v3.4.0', datetime.datetime(2022, 12, 27, 23, 43, 41))])]
+    """
+    supported_versions = []
+    # Prepare dates for later calculation
+    now          = datetime.datetime.now()
+    one_year     = datetime.timedelta(days=365)
+    three_months = datetime.timedelta(days=90)
+
+    # get the newer versions on top
+    sorted_versions_list = sorted(versions.items(), key=lambda x: x[0], reverse=True)
+
+    # the latest version is always supported no matter the release date
+    latest = sorted_versions_list.pop(0)
+    supported_versions.append(latest[1][-1])
+
+    for v in sorted_versions_list:
+        first_release = v[1][-1]
+        last_release  = v[1][0]
+        # if the release is less than a year old we support the latest patch version
+        if now - first_release[1] < one_year:
+            supported_versions.append(last_release)
+        # if the main release is older than a year and has a recent path, this is supported
+        elif now - last_release[1] < three_months:
+            supported_versions.append(last_release)
+    return supported_versions
+
+def get_release_docker_image(repo, version):
+    """
+    Extract docker image name from the release page documentation
+    """
+    output = subprocess.check_output(['gh', 'release', '-R', repo, 'view', version], text=True)
+    #Extract matching image name excluding `
+    match = re.search(r"docker pull ([\.\/\-\:\w\d]*)", output)
+    docker_image = match.group(1) if match else ''
+    return((version, docker_image))
+
+def get_versions_from_releases(repo):
+    """
+    Using `gh` cli get the github releases page details then
+    create a list of grouped version on major.minor 
+    and for each give all major.minor.patch with release dates
+    """
+    # Run the `gh release` command to get the release list
+    output = subprocess.check_output(['gh', 'release', '-R', repo, 'list'], text=True)
+    # Parse the output and group by major and minor version numbers
+    versions = defaultdict(lambda: [])
+    for line in output.strip().split('\n'):
+        parts = line.split('\t')
+        # pprint.pprint(parts)
+        version = parts[0]
+        parsed_version = parse_version(version)
+        if parsed_version is None:
+            continue
+        major, minor, patch = parsed_version
+
+        published = datetime.datetime.strptime(parts[3], '%Y-%m-%dT%H:%M:%SZ')
+        versions[(major, minor)].append((version, published))
+    return(versions)
+
+
+def main():
+    manual = """
+    This script lists the supported versions Github releases according to https://kubernetes-csi.github.io/docs/project-policies.html#support
+    It has been designed to help to update the tables from : https://kubernetes-csi.github.io/docs/sidecar-containers.html\n\n
+    It can take multiple repos as argument, for all CSI sidecars details you can run:
+    ./get_supported_version_csi-sidecar.py -R kubernetes-csi/external-attacher -R kubernetes-csi/external-provisioner -R kubernetes-csi/external-resizer -R kubernetes-csi/external-snapshotter -R kubernetes-csi/livenessprobe -R kubernetes-csi/node-driver-registrar -R kubernetes-csi/external-health-monitor\n
+    With the output you can then update the documentation manually.
+    """
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=manual)
+    parser.add_argument('--repo', '-R', required=True, action='append', dest='repos', help='The name of the repository in the format owner/repo.')
+    parser.add_argument('--display', '-d', action='store_true', help='(default) Display EOL versions with their dates', default=True)
+    parser.add_argument('--doc', '-D', action='store_true', help='Helper to https://kubernetes-csi.github.io/docs/ that prints Docker image for each EOL version')
+
+    args = parser.parse_args()
+
+    # Verify pre-reqs
+    check_gh_command()
+
+    # Process all repos
+    for repo in args.repos:
+        versions = get_versions_from_releases(repo)
+        eol_versions = end_of_life_grouped_versions(versions)
+
+        if args.display:
+            print(f"Supported versions with release date and age of `{repo}`:\n")
+            for version in eol_versions:
+                print(f"{version[0]}\t{version[1].strftime('%Y-%m-%d')}\t{duration_ago(version[1])}")
+
+        # TODO : generate proper doc output for the tables of: https://kubernetes-csi.github.io/docs/sidecar-containers.html
+        if args.doc:
+            print("\nSupported Versions with docker images for each end of life version:\n")
+            for version in eol_versions:
+                _, image = get_release_docker_image(repo, version[0])
+                print(f"{version[0]}\t{image}")
+        print()
+
+if __name__ == '__main__':
+    main()

--- a/release-tools/generate_patch_release_notes.sh
+++ b/release-tools/generate_patch_release_notes.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Usage: generate_patch_release_notes.sh
+#
+# Generates and creates PRs for kubernetes-csi patch releases.
+#
+# Required environment variables
+# CSI_RELEASE_TOKEN: Github token needed for generating release notes
+# GITHUB_USER: Github username to create PRs with
+#
+# Instructions:
+# 1. Login with "gh auth login"
+# 2. Copy this script to the kubernetes-csi directory (one directory above the
+# repos)
+# 3. Update the repos and versions in the $releases array
+# 4. Set environment variables
+# 5. Run script from the kubernetes-csi directory
+#
+# Caveats:
+# - This script doesn't handle regenerating and updating existing PRs yet.
+#   It might work if you comment out the PR creation line
+
+set -e
+set -x
+
+releases=(
+#  "external-attacher 4.4.1"
+#  "external-provisioner 3.6.1"
+#  "external-snapshotter 6.2.3"
+)
+
+function gen_patch_relnotes() {
+  rm out.md || true
+  rm -rf /tmp/k8s-repo || true
+  GITHUB_TOKEN="$CSI_RELEASE_TOKEN" \
+  release-notes --discover=patch-to-latest --branch="$2" \
+    --org=kubernetes-csi --repo="$1" \
+    --required-author="" --markdown-links --output out.md
+}
+
+for rel in "${releases[@]}"; do
+  read -r repo version <<< "$rel"
+
+  # Parse minor version
+  minorPattern="(^[[:digit:]]+\.[[:digit:]]+)\."
+  [[ "$version" =~ $minorPattern ]]
+  minor="${BASH_REMATCH[1]}"
+
+  echo "$repo" "$version" "$minor"
+
+  pushd "$repo/CHANGELOG"
+
+  git fetch upstream
+
+  # Create branch
+  branch="changelog-release-$minor"
+  git checkout master
+  git branch -D "$branch" || true
+  git checkout --track "upstream/release-$minor" -b "$branch"
+
+  # Generate release notes
+  gen_patch_relnotes "$repo" "release-$minor"
+  cat > tmp.md <<EOF
+# Release notes for v$version
+
+[Documentation](https://kubernetes-csi.github.io)
+
+EOF
+
+  cat out.md >> tmp.md
+  echo >> tmp.md
+
+  file="CHANGELOG-$minor.md"
+  cat "$file" >> tmp.md
+  mv tmp.md "$file"
+
+  git add -u
+  git commit -m "Add changelog for $version"
+  git push -f origin "$branch"
+
+  # Create PR
+prbody=$(cat <<EOF
+\`\`\`release-note
+NONE
+\`\`\`
+EOF
+)
+  gh pr create --title="Changelog for v$version" --body "$prbody"  --head "$GITHUB_USER:$branch" --base "release-$minor" --repo="kubernetes-csi/$repo"
+
+  popd
+done

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -78,7 +78,7 @@ version_to_git () {
 # the list of windows versions was matched from:
 # - https://hub.docker.com/_/microsoft-windows-nanoserver
 # - https://hub.docker.com/_/microsoft-windows-servercore
-configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
+configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
 
 # If we have a vendor directory, then use it. We must be careful to only
 # use this for "make" invocations inside the project's repo itself because
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.20" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.21" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below
@@ -101,7 +101,10 @@ configvar CSI_PROW_GINKGO_VERSION v1.7.0 "Ginkgo"
 
 # Ginkgo runs the E2E test in parallel. The default is based on the number
 # of CPUs, but typically this can be set to something higher in the job.
-configvar CSI_PROW_GINKO_PARALLEL "-p" "Ginko parallelism parameter(s)"
+configvar CSI_PROW_GINKGO_PARALLEL "-p" "Ginkgo parallelism parameter(s)"
+
+# Timeout value for the overall ginkgo test suite.
+configvar CSI_PROW_GINKGO_TIMEOUT "1h" "Ginkgo timeout"
 
 # Enables building the code in the repository. On by default, can be
 # disabled in jobs which only use pre-built components.
@@ -196,7 +199,7 @@ kindest/node:v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fc
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.11.0" "CSI driver version"
+configvar CSI_PROW_DRIVER_VERSION "v1.12.0" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"
@@ -237,7 +240,7 @@ configvar CSI_PROW_SIDECAR_E2E_IMPORT_PATH "none" "CSI Sidecar E2E package"
 # of the cluster. The alternative would have been to (cross-)compile csi-sanity
 # and install it inside the cluster, which is not necessarily easier.
 configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
-configvar CSI_PROW_SANITY_VERSION v5.0.0 "csi-test version"
+configvar CSI_PROW_SANITY_VERSION v5.2.0 "csi-test version"
 configvar CSI_PROW_SANITY_PACKAGE_PATH github.com/kubernetes-csi/csi-test "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"
@@ -872,10 +875,17 @@ install_snapshot_controller() {
   cnt=0
   expected_running_pods=$(kubectl apply --dry-run=client -o "jsonpath={.spec.replicas}" -f "$SNAPSHOT_CONTROLLER_YAML")
   expected_namespace=$(kubectl apply --dry-run=client -o "jsonpath={.metadata.namespace}" -f "$SNAPSHOT_CONTROLLER_YAML")
-  while [ "$(kubectl get pods -n "$expected_namespace" -l app=snapshot-controller | grep 'Running' -c)" -lt "$expected_running_pods" ]; do
+  expect_key='app\.kubernetes\.io/name'
+  expected_label=$(kubectl apply --dry-run=client -o "jsonpath={.spec.template.metadata.labels['$expect_key']}" -f "$SNAPSHOT_CONTROLLER_YAML")
+  if [ -z "${expected_label}" ]; then
+    expect_key='app'
+    expected_label=$(kubectl apply --dry-run=client -o "jsonpath={.spec.template.metadata.labels['$expect_key']}" -f "$SNAPSHOT_CONTROLLER_YAML")
+  fi
+  expect_key=${expect_key//\\/}
+  while [ "$(kubectl get pods -n "$expected_namespace" -l "$expect_key"="$expected_label" | grep 'Running' -c)" -lt "$expected_running_pods" ]; do
     if [ $cnt -gt 30 ]; then
         echo "snapshot-controller pod status:"
-        kubectl describe pods -n "$expected_namespace" -l app=snapshot-controller
+        kubectl describe pods -n "$expected_namespace" -l "$expect_key"="$expected_label"
         echo >&2 "ERROR: snapshot controller not ready after over 5 min"
         exit 1
     fi
@@ -1018,10 +1028,10 @@ run_e2e () (
 
     if [ "${name}" == "local" ]; then
         cd "${GOPATH}/src/${CSI_PROW_SIDECAR_E2E_IMPORT_PATH}" &&
-        run_with_loggers env KUBECONFIG="$KUBECONFIG" KUBE_TEST_REPO_LIST="$(if [ -e "${CSI_PROW_WORK}/e2e-repo-list" ]; then echo "${CSI_PROW_WORK}/e2e-repo-list"; fi)" ginkgo -v "$@" "${CSI_PROW_WORK}/e2e-local.test" -- -report-dir "${ARTIFACTS}" -report-prefix local
+        run_with_loggers env KUBECONFIG="$KUBECONFIG" KUBE_TEST_REPO_LIST="$(if [ -e "${CSI_PROW_WORK}/e2e-repo-list" ]; then echo "${CSI_PROW_WORK}/e2e-repo-list"; fi)" ginkgo --timeout="${CSI_PROW_GINKGO_TIMEOUT}" -v "$@" "${CSI_PROW_WORK}/e2e-local.test" -- -report-dir "${ARTIFACTS}" -report-prefix local
     else
         cd "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" &&
-        run_with_loggers env KUBECONFIG="$KUBECONFIG" KUBE_TEST_REPO_LIST="$(if [ -e "${CSI_PROW_WORK}/e2e-repo-list" ]; then echo "${CSI_PROW_WORK}/e2e-repo-list"; fi)" ginkgo -v "$@" "${CSI_PROW_WORK}/e2e.test" -- -report-dir "${ARTIFACTS}" -storage.testdriver="${CSI_PROW_WORK}/test-driver.yaml"
+        run_with_loggers env KUBECONFIG="$KUBECONFIG" KUBE_TEST_REPO_LIST="$(if [ -e "${CSI_PROW_WORK}/e2e-repo-list" ]; then echo "${CSI_PROW_WORK}/e2e-repo-list"; fi)" ginkgo --timeout="${CSI_PROW_GINKGO_TIMEOUT}" -v "$@" "${CSI_PROW_WORK}/e2e.test" -- -report-dir "${ARTIFACTS}" -storage.testdriver="${CSI_PROW_WORK}/test-driver.yaml"
     fi
 )
 
@@ -1310,7 +1320,7 @@ main () {
                 if tests_enabled "parallel"; then
                     # Ignore: Double quote to prevent globbing and word splitting.
                     # shellcheck disable=SC2086
-                    if ! run_e2e parallel ${CSI_PROW_GINKO_PARALLEL} \
+                    if ! run_e2e parallel ${CSI_PROW_GINKGO_PARALLEL} \
                          -focus="$focus" \
                          -skip="$(regex_join "${CSI_PROW_E2E_SERIAL}" "${CSI_PROW_E2E_ALPHA}" "${CSI_PROW_E2E_SKIP}")"; then
                         warn "E2E parallel failed"
@@ -1320,7 +1330,7 @@ main () {
                     # Run tests that are feature tagged, but non-alpha
                     # Ignore: Double quote to prevent globbing and word splitting.
                     # shellcheck disable=SC2086
-                    if ! run_e2e parallel-features ${CSI_PROW_GINKO_PARALLEL} \
+                    if ! run_e2e parallel-features ${CSI_PROW_GINKGO_PARALLEL} \
                          -focus="$focus.*($(regex_join "${CSI_PROW_E2E_FOCUS}"))" \
                          -skip="$(regex_join "${CSI_PROW_E2E_SERIAL}")"; then
                         warn "E2E parallel features failed"
@@ -1368,7 +1378,7 @@ main () {
                 if tests_enabled "parallel-alpha"; then
                     # Ignore: Double quote to prevent globbing and word splitting.
                     # shellcheck disable=SC2086
-                    if ! run_e2e parallel-alpha ${CSI_PROW_GINKO_PARALLEL} \
+                    if ! run_e2e parallel-alpha ${CSI_PROW_GINKGO_PARALLEL} \
                          -focus="$focus.*($(regex_join "${CSI_PROW_E2E_ALPHA}"))" \
                          -skip="$(regex_join "${CSI_PROW_E2E_SERIAL}" "${CSI_PROW_E2E_SKIP}")"; then
                         warn "E2E parallel alpha failed"

--- a/release-tools/pull-test.sh
+++ b/release-tools/pull-test.sh
@@ -25,6 +25,7 @@ CSI_RELEASE_TOOLS_DIR="$(pwd)"
 
 # Update the other repo.
 cd "$PULL_TEST_REPO_DIR"
+git reset --hard # Shouldn't be necessary, but somehow is to avoid "fatal: working tree has modifications.  Cannot add." (https://stackoverflow.com/questions/3623351/git-subtree-pull-says-that-the-working-tree-has-modifications-but-git-status-sa)
 git subtree pull --squash --prefix=release-tools "$CSI_RELEASE_TOOLS_DIR" master
 git log -n2
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR updates release-tools by running `git subtree pull --squash --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master`.

```
Squashed 'release-tools/' changes from 4133d1df..f8c8cc4c
f8c8cc4c Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/237 from msau42/prow
b36b5bfd Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/240 from dannawang0221/upgrade-go-version
adfddcc9 Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/issues/243 from pohly/git-subtree-pull-fix
c4650889 pull-test.sh: avoid "git subtree pull" error
7b175a1e Update csi-test version to v5.2.0
987c90cc Update go version to 1.21 to match k/k
2c625d41 Add script to generate patch release notes
f9d5b9c0 Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/236 from mowangdk/feature/bump_csi-driver-host-path_version
b01fd537 Bump csi-driver-host-path version up to v1.12.0
984feece Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/234 from siddhikhapare/csi-tools
1f7e6059 fixed broken links of testgrid dashboard
de2fba88 Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/issues/233 from andyzhangx/andyzhangx-patch-1
cee895e1 remove windows 20H2 build since it's EOL long time ago
670bb0ef Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/229 from marosset/fix-codespell-errors
35d5e783 Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/issues/219 from yashsingh74/update-registry
63473cc9 Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/231 from coulof/bump-go-version-1.20.5
29a5c76c Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/228 from mowangdk/chore/adopt_kubernetes_recommand_labels
8dd28211 Update cloudbuild image with go 1.20.5
1df23dba Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/230 from msau42/prow
1f92b7e7 Add ginkgo timeout to e2e tests to help catch any stuck tests
2b8b80ea fixing some codespell errors
c10b6780 Merge pull request https://github.com/kubernetes-csi/csi-driver-host-path/pull/227 from coulof/check-sidecar-supported-versions
72984ec0 chore: adopt kubernetes recommand label
b0555351 Header
bd0a10b6 typo
c39d73c3 Add comments
f6491af0 Script to verify EOL sidecar version
901bcb5a Update registry k8s.gcr.io -> registry.k8s.io

git-subtree-dir: release-tools
git-subtree-split: f8c8cc4c7414c11526f14649856ff8e6b8a4e67c
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
