### PR TITLE
GetVolumeGroupSnapshot should check SnapshotIDs not SourceVolumeIDs

### DIFF
--- a/pkg/hostpath/groupcontrollerserver.go
+++ b/pkg/hostpath/groupcontrollerserver.go
@@ -237,7 +237,7 @@ func (hp *hostPath) GetVolumeGroupSnapshot(ctx context.Context, req *csi.GetVolu
 		return nil, err
 	}
 
-	if !groupSnapshot.MatchesSourceVolumeIDs(req.GetSnapshotIds()) {
+	if !groupSnapshot.MatchesSnapshotIDs(req.GetSnapshotIds()) {
 		return nil, status.Error(codes.InvalidArgument, "Snapshot IDs do not match the GroupSnapshot IDs")
 	}
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -338,18 +338,24 @@ func (s *state) DeleteGroupSnapshot(groupSnapshotID string) error {
 }
 
 func (gs *GroupSnapshot) MatchesSourceVolumeIDs(sourceVolumeIDs []string) bool {
-	stateSourceVolumeIDs := gs.SourceVolumeIDs
+	return equalIDs(gs.SourceVolumeIDs, sourceVolumeIDs)
+}
 
-	if len(stateSourceVolumeIDs) != len(sourceVolumeIDs) {
+func (gs *GroupSnapshot) MatchesSnapshotIDs(snapshotIDs []string) bool {
+	return equalIDs(gs.SnapshotIDs, snapshotIDs)
+}
+
+func equalIDs(a, b []string) bool {
+	if len(a) != len(b) {
 		return false
 	}
 
 	// sort slices so that values are at the same location
-	sort.Strings(stateSourceVolumeIDs)
-	sort.Strings(sourceVolumeIDs)
+	sort.Strings(a)
+	sort.Strings(b)
 
-	for i, v := range stateSourceVolumeIDs {
-		if v != sourceVolumeIDs[i] {
+	for i, v := range a {
+		if v != b[i] {
 			return false
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Due to this bug in GetVolumeGroupSnapshot, creating pre-provisioned
VolumeGroupSnapshots was not working. Pre-provisioned
VolumeGroupSnapshots refer to a list of SnapshotIDs that are part of the
VolumeGroupSnapshot, the SourceVolumeIDs are not used in that case.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Tested with kubernetes-csi/external-snapshotter#837

**Does this PR introduce a user-facing change?**:

```release-note
Fix an issue with GetVolumeGroupSnapshot where SourceVolumeIDs were compared with SnapshotIDs.
```
