### PR TITLE
replace socat image with hostpathplugin image and bump image versions

### DIFF
--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-plugin.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: csi-external-health-monitor-controller
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.12.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-snapshotter.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-testing.yaml
@@ -64,7 +64,9 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: docker.io/alpine/socat:1.7.4.3-r0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
+          command:
+          - socat
           args:
             - tcp-listen:10000,fork,reuseaddr
             - unix-connect:/csi/csi.sock

--- a/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
@@ -219,7 +219,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.12.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -354,7 +354,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.27/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.27/hostpath/csi-hostpath-testing.yaml
@@ -66,7 +66,9 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: docker.io/alpine/socat:1.7.4.3-r0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
+          command:
+          - socat
           args:
             - tcp-listen:10000,fork,reuseaddr
             - unix-connect:/csi/csi.sock

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.3
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -60,7 +60,7 @@ spec:
               name: socket-dir
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.3
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -85,7 +85,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
           args:
             - --drivername=hostpath.csi.k8s.io
             - --v=5
@@ -132,7 +132,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-testing.yaml
@@ -64,7 +64,9 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: docker.io/alpine/socat:1.7.4.3-r0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
+          command:
+          - socat
           args:
             - tcp-listen:10000,fork,reuseaddr
             - unix-connect:/csi/csi.sock


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

 A follow up PR https://github.com/kubernetes-csi/csi-driver-host-path/pull/498

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

need cut a release v1.13.0

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Replace socat image with hostpathplugin image
```
