### PR TITLE
fix broken symbolic link in deploy dir

### DIFF
--- a/deploy/kubernetes-1.27-test/kubernetes-1.27-test
+++ b/deploy/kubernetes-1.27-test/kubernetes-1.27-test
@@ -1,1 +1,0 @@
-kubernetes-1.27-test

--- a/deploy/kubernetes-1.27/kubernetes-1.26
+++ b/deploy/kubernetes-1.27/kubernetes-1.26
@@ -1,1 +1,0 @@
-kubernetes-1.26

--- a/deploy/kubernetes-1.27/kubernetes-1.27
+++ b/deploy/kubernetes-1.27/kubernetes-1.27
@@ -1,1 +1,0 @@
-kubernetes-1.27

--- a/deploy/kubernetes-1.27/kubernetes-1.28
+++ b/deploy/kubernetes-1.27/kubernetes-1.28
@@ -1,1 +1,0 @@
-kubernetes-1.28

--- a/deploy/kubernetes-1.28
+++ b/deploy/kubernetes-1.28
@@ -1,1 +1,1 @@
-deploy/kubernetes-1.27
+kubernetes-1.27

--- a/deploy/kubernetes-1.28-test
+++ b/deploy/kubernetes-1.28-test
@@ -1,1 +1,1 @@
-deploy/kubernetes-1.27-test
+kubernetes-1.27-test

--- a/deploy/kubernetes-latest
+++ b/deploy/kubernetes-latest
@@ -1,1 +1,1 @@
-./deploy/kubernetes-1.28
+kubernetes-1.28

--- a/deploy/kubernetes-latest-test
+++ b/deploy/kubernetes-latest-test
@@ -1,1 +1,1 @@
-./deploy/kubernetes-1.28-test
+kubernetes-1.28-test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

```
(⎈|kind-test:N/A)➜  csi-driver-host-path git:(release-1.12) ll deploy
total 0
drwxr-xr-x  10 kiki  staff   320B Mar  4 11:07 kubernetes-1.26
drwxr-xr-x   8 kiki  staff   256B Mar  4 11:07 kubernetes-1.26-test
lrwxr-xr-x   1 kiki  staff    15B Mar  4 11:07 kubernetes-1.27 -> kubernetes-1.26
lrwxr-xr-x   1 kiki  staff    20B Mar  4 11:07 kubernetes-1.27-test -> kubernetes-1.26-test
drwxr-xr-x   8 kiki  staff   256B Mar  3 11:41 kubernetes-distributed
lrwxr-xr-x   1 kiki  staff    15B Mar  4 11:07 kubernetes-latest -> kubernetes-1.27
lrwxr-xr-x   1 kiki  staff    20B Mar  4 11:07 kubernetes-latest-test -> kubernetes-1.27-test
drwxr-xr-x   4 kiki  staff   128B Mar  3 11:41 util
(⎈|kind-test:N/A)➜  csi-driver-host-path git:(release-1.12) cd deploy/kubernetes-latest
(⎈|kind-test:N/A)➜  kubernetes-latest git:(release-1.12)


(⎈|kind-test:N/A)➜  csi-driver-host-path git:(release-1.12) git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
(⎈|kind-test:N/A)➜  csi-driver-host-path git:(master)
(⎈|kind-test:N/A)➜  csi-driver-host-path git:(master) ll deploy
total 0
drwxr-xr-x  10 kiki  staff   320B Mar  4 11:07 kubernetes-1.27
drwxr-xr-x   8 kiki  staff   256B Mar  4 11:07 kubernetes-1.27-test
lrwxr-xr-x   1 kiki  staff    22B Mar  4 11:07 kubernetes-1.28 -> deploy/kubernetes-1.27
lrwxr-xr-x   1 kiki  staff    27B Mar  4 11:07 kubernetes-1.28-test -> deploy/kubernetes-1.27-test
drwxr-xr-x   8 kiki  staff   256B Mar  3 11:41 kubernetes-distributed
lrwxr-xr-x   1 kiki  staff    24B Mar  4 11:07 kubernetes-latest -> ./deploy/kubernetes-1.28
lrwxr-xr-x   1 kiki  staff    29B Mar  4 11:07 kubernetes-latest-test -> ./deploy/kubernetes-1.28-test
drwxr-xr-x   4 kiki  staff   128B Mar  3 11:41 util

(⎈|kind-test:N/A)➜  csi-driver-host-path git:(master) cd deploy/kubernetes-latest
cd: no such file or directory: deploy/kubernetes-latest
```

Related-to: https://github.com/kubernetes-csi/csi-driver-host-path/pull/501

/cc @RaunakShah @xing-yang 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix broken symbolic links in the deploy dir
```
