### PR TITLE
bump image versions

### DIFF
--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-attacher.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.6.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-plugin.yaml
@@ -83,7 +83,7 @@ spec:
           - --health-port=9898
 
         - name: csi-external-health-monitor-controller
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.11.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -97,7 +97,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-provisioner.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-resizer.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.11.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-snapshotter.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
@@ -262,7 +262,7 @@ spec:
               name: dev-dir
 
         - name: csi-external-health-monitor-controller
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.11.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -276,7 +276,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -310,7 +310,7 @@ spec:
           - --health-port=9898
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.6.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -324,7 +324,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -340,7 +340,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.11.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
@@ -354,7 +354,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -60,7 +60,7 @@ spec:
               name: socket-dir
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Prepare to update kubernetes e2e manifests. HonorPVReclaimPolicy is promoted to beta in `csi-provisioner:v5.0.0`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/pull/124842

**Special notes for your reviewer**:

/hold

```
We are working on cutting new releases of all sidecars before updating csi hostpath manifests and cutting a new release of csi hostpath.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
bump image versions
```
