### PR TITLE
Bump hostpath image v1.15.0 in deploy

### DIFF
--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-plugin.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: csi-external-health-monitor-controller
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.14.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.27-test/hostpath/csi-hostpath-testing.yaml
@@ -64,7 +64,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.14.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
           command:
           - socat
           args:

--- a/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
@@ -219,7 +219,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.14.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.27/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-1.27/hostpath/csi-hostpath-testing.yaml
@@ -66,7 +66,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.14.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
           command:
           - socat
           args:

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -85,7 +85,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.14.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
           args:
             - --drivername=hostpath.csi.k8s.io
             - --v=5

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-testing.yaml
@@ -64,7 +64,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.14.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
           command:
           - socat
           args:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Bump hostpath image to v1.15.0

A follow-up of https://github.com/kubernetes/k8s.io/pull/7265

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump hostpath image to v1.15.0 in /deploy
```
