### PR TITLE
update app label key in docs/deploy-1.17-and-later.md

### DIFF
--- a/docs/deploy-1.17-and-later.md
+++ b/docs/deploy-1.17-and-later.md
@@ -237,7 +237,7 @@ $ kubectl exec -it my-csi-app /bin/sh
 
 Next, ssh into the Hostpath container and verify that the file shows up there:
 ```shell
-$ kubectl exec -it $(kubectl get pods --selector app=csi-hostpathplugin -o jsonpath='{.items[*].metadata.name}') -c hostpath /bin/sh
+$ kubectl exec -it $(kubectl get pods --selector app.kubernetes.io/name=csi-hostpathplugin -o jsonpath='{.items[*].metadata.name}') -c hostpath /bin/sh
 
 ```
 Then, use the following command to locate the file. If everything works OK you should get a result similar to the following:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

There is a wrong label key in docs/deploy-1.17-and-later.md, which is already updated in deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml from app to app.kubernetes.io/name. If this error is not corrected, it will not be possible to continue as instructed in the document.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

NONE

```release-note
none
```
