### PR TITLE
Add documentation to deploy and test SnapshotMetadata support

### DIFF
--- a/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
@@ -237,9 +237,8 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          # TODO: Revert comment once https://github.com/kubernetes-csi/csi-driver-host-path/pull/569 is merged
-          #image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
-          image: prasadg193/hostpathplugin:amd64-linux-canary
+          # TODO: Set release tag after new release is made with SnapshotMetadata support
+          image: gcr.io/k8s-staging-sig-storage/hostpathplugin:canary
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
@@ -237,8 +237,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          # TODO: Set release tag after new release is made with SnapshotMetadata support
-          image: gcr.io/k8s-staging-sig-storage/hostpathplugin:canary
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.27/hostpath/csi-hostpath-plugin.yaml
@@ -102,6 +102,24 @@ subjects:
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: snapshot-metadata-cluster-role
+  name: csi-hostpathplugin-snapshot-metadata-cluster-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-snapshot-metadata-runner
+subjects:
+- kind: ServiceAccount
+  name: csi-hostpathplugin-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -219,12 +237,15 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
+          # TODO: Revert comment once https://github.com/kubernetes-csi/csi-driver-host-path/pull/569 is merged
+          #image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
+          image: prasadg193/hostpathplugin:amd64-linux-canary
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
+            # end hostpath args
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -367,6 +388,8 @@ spec:
             - mountPath: /csi
               name: socket-dir
 
+        # end csi containers
+
       volumes:
         - hostPath:
             path: /var/lib/kubelet/plugins/csi-hostpath
@@ -394,3 +417,4 @@ spec:
             path: /dev
             type: Directory
           name: dev-dir
+        # end csi volumes

--- a/deploy/kubernetes-1.27/hostpath/csi-snapshot-metadata-sidecar.patch
+++ b/deploy/kubernetes-1.27/hostpath/csi-snapshot-metadata-sidecar.patch
@@ -1,0 +1,23 @@
+        - name: csi-snapshot-metadata
+          # TODO: Replace main tag with actual released tag once external-snapshot-metadata is released
+          image: gcr.io/k8s-staging-sig-storage/csi-snapshot-metadata:main
+          imagePullPolicy: "Always"
+          command:
+          args:
+          - "--csi-address=/csi/csi.sock"
+          - "--tls-cert=/tmp/certificates/tls.crt"
+          - "--tls-key=/tmp/certificates/tls.key"
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/grpc_health_probe"
+              - "-addr=:50051"
+              - "-tls"
+              - "-tls-no-verify"
+            initialDelaySeconds: 5
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - name: csi-snapshot-metadata-server-certs
+              mountPath: /tmp/certificates
+              readOnly: true

--- a/deploy/kubernetes-1.27/hostpath/csi-snapshot-metadata-sidecar.patch
+++ b/deploy/kubernetes-1.27/hostpath/csi-snapshot-metadata-sidecar.patch
@@ -1,7 +1,7 @@
         - name: csi-snapshot-metadata
           # TODO: Replace main tag with actual released tag once external-snapshot-metadata is released
           image: gcr.io/k8s-staging-sig-storage/csi-snapshot-metadata:canary
-          imagePullPolicy: "Always"
+          imagePullPolicy: "IfNotPresent"
           command:
           args:
           - "--csi-address=/csi/csi.sock"

--- a/deploy/kubernetes-1.27/hostpath/csi-snapshot-metadata-sidecar.patch
+++ b/deploy/kubernetes-1.27/hostpath/csi-snapshot-metadata-sidecar.patch
@@ -1,6 +1,6 @@
         - name: csi-snapshot-metadata
           # TODO: Replace main tag with actual released tag once external-snapshot-metadata is released
-          image: gcr.io/k8s-staging-sig-storage/csi-snapshot-metadata:main
+          image: gcr.io/k8s-staging-sig-storage/csi-snapshot-metadata:canary
           imagePullPolicy: "Always"
           command:
           args:

--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -171,10 +171,9 @@ CSI_RESIZER_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external
 CSI_EXTERNALHEALTH_MONITOR_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-plugin.yaml" csi-external-health-monitor-controller false)/deploy/kubernetes/external-health-monitor-controller/rbac.yaml"
 : ${CSI_EXTERNALHEALTH_MONITOR_RBAC:=https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-plugin.yaml" csi-external-health-monitor-controller "${UPDATE_RBAC_RULES}")/deploy/kubernetes/external-health-monitor-controller/rbac.yaml}
 
-# TODO: Replace with external-snapshot-metadata link once https://github.com/kubernetes-csi/external-snapshot-metadata/pull/84 is merged
-CSI_SNAPSHOT_METADATA_TLS_CERT_YAML="https://raw.githubusercontent.com/PrasadG193/k8s-external-snapshot-metadata/refs/heads/add-testdata/deploy/example/csi-driver/testdata/csi-snapshot-metadata-tls-secret.yaml"
-SNAPSHOT_METADATA_SERVICE_CR_YAML="https://raw.githubusercontent.com/PrasadG193/k8s-external-snapshot-metadata/refs/heads/add-testdata/deploy/example/csi-driver/testdata/snapshotmetadataservice.yaml"
-CSI_SNAPSHOT_METADATA_SERVICE_YAML="https://raw.githubusercontent.com/PrasadG193/k8s-external-snapshot-metadata/refs/heads/add-testdata/deploy/example/csi-driver/testdata/csi-snapshot-metadata-service.yaml"
+CSI_SNAPSHOT_METADATA_TLS_CERT_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/$(rbac_version "${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata false)/deploy/example/csi-driver/testdata/csi-snapshot-metadata-tls-secret.yaml"
+SNAPSHOT_METADATA_SERVICE_CR_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/$(rbac_version "${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata false)/deploy/example/csi-driver/testdata/snapshotmetadataservice.yaml"
+CSI_SNAPSHOT_METADATA_SERVICE_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/$(rbac_version "${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata false)/deploy/example/csi-driver/testdata/csi-snapshot-metadata-service.yaml"
 
 INSTALL_CRD=${INSTALL_CRD:-"false"}
 

--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -190,7 +190,11 @@ run () {
 
 # rbac rules
 echo "applying RBAC rules"
-for component in CSI_PROVISIONER CSI_ATTACHER CSI_SNAPSHOTTER CSI_RESIZER CSI_EXTERNALHEALTH_MONITOR CSI_SNAPSHOT_METADATA; do
+components=(CSI_PROVISIONER CSI_ATTACHER CSI_SNAPSHOTTER CSI_RESIZER CSI_EXTERNALHEALTH_MONITOR)
+if snapshot_metadata; then
+    components+=(CSI_SNAPSHOT_METADATA)
+fi
+for component in "${components[@]}"; do
     eval current="\${${component}_RBAC}"
     eval original="\${${component}_RBAC_YAML}"
     if [ "$current" != "$original" ]; then

--- a/deploy/util/deploy-hostpath.sh
+++ b/deploy/util/deploy-hostpath.sh
@@ -171,7 +171,7 @@ CSI_RESIZER_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external
 CSI_EXTERNALHEALTH_MONITOR_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-plugin.yaml" csi-external-health-monitor-controller false)/deploy/kubernetes/external-health-monitor-controller/rbac.yaml"
 : ${CSI_EXTERNALHEALTH_MONITOR_RBAC:=https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-plugin.yaml" csi-external-health-monitor-controller "${UPDATE_RBAC_RULES}")/deploy/kubernetes/external-health-monitor-controller/rbac.yaml}
 
-# TODO: Replace with external-snapshot-metadata link
+# TODO: Replace with external-snapshot-metadata link once https://github.com/kubernetes-csi/external-snapshot-metadata/pull/84 is merged
 CSI_SNAPSHOT_METADATA_TLS_CERT_YAML="https://raw.githubusercontent.com/PrasadG193/k8s-external-snapshot-metadata/refs/heads/add-testdata/deploy/example/csi-driver/testdata/csi-snapshot-metadata-tls-secret.yaml"
 SNAPSHOT_METADATA_SERVICE_CR_YAML="https://raw.githubusercontent.com/PrasadG193/k8s-external-snapshot-metadata/refs/heads/add-testdata/deploy/example/csi-driver/testdata/snapshotmetadataservice.yaml"
 CSI_SNAPSHOT_METADATA_SERVICE_YAML="https://raw.githubusercontent.com/PrasadG193/k8s-external-snapshot-metadata/refs/heads/add-testdata/deploy/example/csi-driver/testdata/csi-snapshot-metadata-service.yaml"

--- a/docs/example-snapshot-metadata.md
+++ b/docs/example-snapshot-metadata.md
@@ -142,9 +142,9 @@ This client performs following actions:
     Wait for snapshot to be ready
 
     ```
-    $ kg vs snapshot-1
-    NAME         READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS            SNAPSHOTCONTENT                                    CREATIONTIME   AGE
-    snapshot-1   true         pvc-raw                             10Mi          csi-hostpath-snapclass   snapcontent-70b40b27-80d4-448b-bd9a-a87079c1a248   28s            29s
+    $ kubectl get vs raw-pvc-snap-1
+    NAME             READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS            SNAPSHOTCONTENT                                    CREATIONTIME   AGE
+    raw-pvc-snap-1   true         pvc-raw                             10Mi          csi-hostpath-snapclass   snapcontent-e17ba543-b8be-4a8e-9b0f-d708d664a0ee   99s            100s
     ```
 
 5. Now, inside `csi-client` pod which is created in previous steps, use `snapshot-metadata-lister` tool query allocated blocks metadata

--- a/docs/example-snapshot-metadata.md
+++ b/docs/example-snapshot-metadata.md
@@ -59,7 +59,7 @@ Follow the following steps to setup client with all the required permissions:
 2. Deploy sample client pod which contains [snapshot-metadata-lister](https://github.com/kubernetes-csi/external-snapshot-metadata) tool which can be used as a client to call SnapshotMetadata APIs
 
     ```
-    $ kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/main/examples/snapshot-metadata-lister/deploy/snapshot-medata-lister-pod.yaml -n csi-client
+    $ kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/main/examples/snapshot-metadata-lister/deploy/snapshot-metadata-lister-pod.yaml -n csi-client
     ```
 
 This client performs following actions:

--- a/docs/example-snapshot-metadata.md
+++ b/docs/example-snapshot-metadata.md
@@ -19,7 +19,7 @@ Follow the steps below to deploy CSI Hostpath driver with SnapshotMetadata servi
   b. Execute deploy script to setup hostpath plugin driver with external-snapshot-metadata change
 
   ```
-  $ SNAPSHOT_METADATA_TESTS=true ./deploy/kubernetes-1.27/deploy.sh
+  $ SNAPSHOT_METADATA_TESTS=true HOSTPATHPLUGIN_REGISTRY=gcr.io/k8s-staging-sig-storage HOSTPATHPLUGIN_TAG=canary ./deploy/kubernetes-1.27/deploy.sh
   ```
 
 ### Setup SnapshotMetadata client

--- a/docs/example-snapshot-metadata.md
+++ b/docs/example-snapshot-metadata.md
@@ -1,0 +1,268 @@
+## Snapshot Changed Block Metadata Support
+
+The CSI HostPath driver now includes support for the CSI [SnapshotMetadata](https://github.com/container-storage-interface/spec/blob/master/csi.proto#L130) service. This service provides APIs to retrieve metadata about the allocated blocks of a CSI VolumeSnapshot or the changed blocks between any two CSI VolumeSnapshot objects of the same PersistentVolume.
+
+This document outlines the steps to test this feature on a Kubernetes cluster.
+
+### Deploying CSI Hostpath driver with SnapshotMetadata service
+
+Setting up CSI Hostpath driver with SnapshotMetadata service requires provisioning TLS certificates, creating TLS secrets, SnapshotMetadata custom resource, patching up csi-hostpathplugin deployments, etc. These steps are automated in `deploy.sh` script used to deploy CSI Hostpath driver.
+
+Follow the steps below to deploy CSI Hostpath driver with SnapshotMetadata service:
+
+  a. Create `SnapshotMetadata` CRD
+
+  ```
+  $ kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/main/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml
+  ```
+
+  b. Execute deploy script to setup hostpath plugin driver with external-snapshot-metadata change
+
+  ```
+  $ SNAPSHOT_METADATA_TESTS=true ./deploy/kubernetes-1.27/deploy.sh
+  ```
+
+### Sample SnapshotMetadata client
+
+The `SnapshotMetadata` service implements gRPC APIs. A gRPC client can query these APIs to retrieve metadata about the allocated blocks of a CSI VolumeSnapshot or the changed blocks between any two CSI VolumeSnapshot objects.
+
+For our testing, we will be using a sample client implementation in Go provided as a example in [external-snapshot-metadata](https://github.com/kubernetes-csi/external-snapshot-metadata/tree/main/examples/snapshot-metadata-lister) repo.
+
+Follow the following steps to setup client with all the required permissions:
+
+1. Setup RBAC
+
+   a. Create `ClusterRole` containing all the required permissions for the client
+
+   ```bash
+   $ kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/main/deploy/snapshot-metadata-client-cluster-role.yaml
+   ```
+
+   b. Create a namespace to deploy client
+
+   ```
+   $ kubectl create namespace csi-client
+   ```
+
+   c. Create service account
+
+   ```
+   $ kubectl create serviceaccount csi-client-sa -n csi-client
+   ```
+
+   d. Bind the clusterrole to the service account
+
+   ```
+   $ kubectl create clusterrolebinding csi-client-cluster-role-binding --clusterrole=external-snapshot-metadata-client-runner --serviceaccount=csi-client:csi-client-sa
+   ```
+
+2. Deploy sample client pod
+
+    Create a pod in which we'll be installing and running the client
+
+    ```
+    $ kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: csi-client
+      namespace: csi-client
+    spec:
+      containers:
+      - name: golang
+        image: golang:1.23.4
+        command: ["tail", "-f", "/dev/null"]
+      serviceAccountName: csi-client-sa
+    EOF
+    ```
+
+3. Install SnapshotMetadata client in the pod
+
+    Exec into the pod, clone the client repo and build the client from source
+
+    ```
+    $ kubectl exec -ti -n csi-client csi-client -- bash
+
+    ## Install snapshot-metadata-lister
+    root@csi-client:/go# go install github.com/kubernetes-csi/external-snapshot-metadata/examples/snapshot-metadata-lister@latest
+    ```
+
+
+This client performs following actions:
+1. Find Driver name for the snapshot.
+2. Discover `SnapshotMetadataService` resource for the driver which contains endpoint, audience and CA cert.
+3. Create SA Token with expected audience and permissions.
+4. Make gRPC call `GetMetadataAllocated` and `GetMetadataDelta` with appropriate params from `SnapshotMetadataService` resource, generated SA token.
+5. Stream response and print on console.
+
+
+### Test GetMetadataAllocated
+
+1. Create CSI Hostpath storageclass
+
+    ```
+    $ kubectl create -f examples/csi-storageclass.yaml
+    ```
+
+2. Create a volume with Block mode access
+
+    ```
+    kubectl apply -f - <<EOF
+    kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: pvc-raw
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: csi-hostpath-sc
+      volumeMode: Block
+      resources:
+        requests:
+          storage: 10Mi
+    EOF
+    ```
+
+3. Mount the PVC to a pod
+
+    ```
+    kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod-raw
+      labels:
+        name: busybox-test
+    spec:
+      restartPolicy: Always
+      containers:
+        - image: gcr.io/google_containers/busybox
+          command: ["/bin/sh", "-c"]
+          args: [ "tail -f /dev/null" ]
+          name: busybox
+          volumeDevices:
+            - name: vol
+              devicePath: /dev/loop3
+      volumes:
+        - name: vol
+          persistentVolumeClaim:
+            claimName: pvc-raw
+    EOF
+    ```
+
+4. Snapshot PVC `pvc-raw`
+
+    ```
+    kubectl apply -f - <<EOF
+    apiVersion: snapshot.storage.k8s.io/v1
+    kind: VolumeSnapshot
+    metadata:
+      name: raw-pvc-snap-1
+    spec:
+      volumeSnapshotClassName: csi-hostpath-snapclass
+      source:
+        persistentVolumeClaimName: pvc-raw
+    EOF
+    ```
+
+    Wait for snapshot to be ready
+
+    ```
+    $ kg vs snapshot-1
+    NAME         READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS            SNAPSHOTCONTENT                                    CREATIONTIME   AGE
+    snapshot-1   true         pvc-raw                             10Mi          csi-hostpath-snapclass   snapcontent-70b40b27-80d4-448b-bd9a-a87079c1a248   28s            29s
+    ```
+
+5. Now, inside `csi-client` pod which is created in previous steps, use `snapshot-metadata-lister` tool query allocated blocks metadata
+
+    ```
+    $ kubectl exec -n csi-client csi-client -- snapshot-metadata-lister -n default -s raw-pvc-snap-1
+
+    Record#   VolCapBytes  BlockMetadataType   ByteOffset     SizeBytes   
+    ------- -------------- ----------------- -------------- --------------
+          1       10485760      FIXED_LENGTH              0           4096
+          1       10485760      FIXED_LENGTH           4096           4096
+          1       10485760      FIXED_LENGTH           8192           4096
+          1       10485760      FIXED_LENGTH          12288           4096
+          1       10485760      FIXED_LENGTH          16384           4096
+          1       10485760      FIXED_LENGTH          20480           4096
+          1       10485760      FIXED_LENGTH          24576           4096
+          1       10485760      FIXED_LENGTH          28672           4096
+          1       10485760      FIXED_LENGTH          32768           4096
+          1       10485760      FIXED_LENGTH          36864           4096
+          1       10485760      FIXED_LENGTH          40960           4096
+    .
+    .
+    .
+    .
+         10       10485760      FIXED_LENGTH       10452992           4096
+         10       10485760      FIXED_LENGTH       10457088           4096
+         10       10485760      FIXED_LENGTH       10461184           4096
+         10       10485760      FIXED_LENGTH       10465280           4096
+         10       10485760      FIXED_LENGTH       10469376           4096
+         10       10485760      FIXED_LENGTH       10473472           4096
+         10       10485760      FIXED_LENGTH       10477568           4096
+         10       10485760      FIXED_LENGTH       10481664           4096
+    ```
+
+
+### Test GetMetadataDelta
+
+1. Change couple of blocks in the mounted device file in `pod-raw` Pod
+
+    ```
+    $ kubectl exec -ti pod-raw -- sh
+
+    ### change blocks 12, 13, 15 and 20
+    / # dd if=/dev/urandom of=/dev/loop3 bs=4K count=1 seek=12 conv=notrunc
+    1+0 records in
+    1+0 records out
+    / # dd if=/dev/urandom of=/dev/loop3 bs=4K count=1 seek=13 conv=notrunc
+    1+0 records in
+    1+0 records out
+    / # dd if=/dev/urandom of=/dev/loop3 bs=4K count=1 seek=15 conv=notrunc
+    1+0 records in
+    1+0 records out
+    / # dd if=/dev/urandom of=/dev/loop3 bs=4K count=1 seek=20 conv=notrunc
+    1+0 records in
+    1+0 records out
+
+    ```
+
+2. Snapshot `pvc-raw` again
+
+    ```
+    kubectl apply -f - <<EOF
+    apiVersion: snapshot.storage.k8s.io/v1
+    kind: VolumeSnapshot
+    metadata:
+      name: raw-pvc-snap-2
+    spec:
+      volumeSnapshotClassName: csi-hostpath-snapclass
+      source:
+        persistentVolumeClaimName: pvc-raw
+    EOF
+    ```
+
+    Wait for snapshot to be ready
+
+    ```
+    $ kubectl get vs
+    NAME             READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS            SNAPSHOTCONTENT                                    CREATIONTIME   AGE
+    raw-pvc-snap-1   true         pvc-raw                             10Mi          csi-hostpath-snapclass   snapcontent-ef10f725-4261-4e80-af37-906708796700   7m40s          7m40s
+    raw-pvc-snap-2   true         pvc-raw                             10Mi          csi-hostpath-snapclass   snapcontent-188562cb-03b3-4b70-b12d-28900527bca8   23s            23s
+    ```
+
+3. Using `external-snapshot-metadata-client` which uses `GetMetadataDelta` gRPC to allocated blocks metadata
+
+    ```
+    $ kubectl exec -n csi-client csi-client -- snapshot-metadata-lister -n default -s raw-pvc-snap-1 -p raw-pvc-snap-2
+
+
+    Record#   VolCapBytes  BlockMetadataType   ByteOffset     SizeBytes
+    ------- -------------- ----------------- -------------- --------------
+          1       10485760      FIXED_LENGTH          49152           4096
+          1       10485760      FIXED_LENGTH          53248           4096
+          1       10485760      FIXED_LENGTH          61440           4096
+          1       10485760      FIXED_LENGTH          81920           4096
+    ```

--- a/docs/example-snapshot-metadata.md
+++ b/docs/example-snapshot-metadata.md
@@ -223,7 +223,7 @@ This client performs following actions:
     ```
     $ kubectl get vs
     NAME             READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS            SNAPSHOTCONTENT                                    CREATIONTIME   AGE
-    raw-pvc-snap-1   true         pvc-raw                             10Mi          csi-hostpath-snapclass   snapcontent-ef10f725-4261-4e80-af37-906708796700   7m40s          7m40s
+    raw-pvc-snap-1   true         pvc-raw                             10Mi          csi-hostpath-snapclass   snapcontent-e17ba543-b8be-4a8e-9b0f-d708d664a0ee   7m40s          7m40s
     raw-pvc-snap-2   true         pvc-raw                             10Mi          csi-hostpath-snapclass   snapcontent-188562cb-03b3-4b70-b12d-28900527bca8   23s            23s
     ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR related to the SnapshotMetadata service support added with - https://github.com/kubernetes-csi/csi-driver-host-path/pull/569

This PR:
- Updates deploy.sh script to deploy csi-hostpathplugin with [external-snapshot-metadata](https://github.com/kubernetes-csi/external-snapshot-metadata) support.
- Add documentation for steps to deploy and test `SnapshotMetadata` support.


Steps to deploy csi hostpath driver with `snapshot-metadata` service using `deploy.sh` script:

1. Install `SnapshotMetadataService` CRD using the following command
```shell
$ VERSION=main
$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotmetadata/${VERSION}/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml
```

2. Deploy csi hostpath driver with `snapshot-metadata` service using the following command:
```shell
$ SNAPSHOT_METADATA_TESTS=true deploy/kubernetes-latest/deploy.sh
```

```release-note
NONE
```
