### PR TITLE
Create Helm Chart from Static Manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/csi-hostpathplugin/.helmignore
+++ b/charts/csi-hostpathplugin/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/csi-hostpathplugin/Chart.yaml
+++ b/charts/csi-hostpathplugin/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: csi-hostpathplugin
+description: A Helm chart for deploy the CSI Hostpath driver
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: v1.17.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: v1.17.1

--- a/charts/csi-hostpathplugin/templates/CSI_ATTACHER-rbac.yaml
+++ b/charts/csi-hostpathplugin/templates/CSI_ATTACHER-rbac.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-attacher
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-attacher-runner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csinodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattachments/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-attacher
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-attacher-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: external-attacher-cfg
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role-cfg
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-attacher
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: external-attacher-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/csi-hostpathplugin/templates/CSI_EXTERNALHEALTH_MONITOR-rbac.yaml
+++ b/charts/csi-hostpathplugin/templates/CSI_EXTERNALHEALTH_MONITOR-rbac.yaml
@@ -1,0 +1,98 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-external-health-monitor-controller
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-health-monitor-controller-runner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-external-health-monitor-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-external-health-monitor-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-health-monitor-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: external-health-monitor-controller-cfg
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-external-health-monitor-controller-role-cfg
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-external-health-monitor-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: external-health-monitor-controller-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/csi-hostpathplugin/templates/CSI_PROVISIONER-rbac.yaml
+++ b/charts/csi-hostpathplugin/templates/CSI_PROVISIONER-rbac.yaml
@@ -1,0 +1,156 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-provisioner
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-runner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotcontents
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csinodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: external-provisioner-cfg
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csistoragecapacities
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role-cfg
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: external-provisioner-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/csi-hostpathplugin/templates/CSI_RESIZER-rbac.yaml
+++ b/charts/csi-hostpathplugin/templates/CSI_RESIZER-rbac.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-resizer
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-resizer-runner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattributesclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-resizer
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-resizer-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: external-resizer-cfg
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role-cfg
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-resizer
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: external-resizer-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/csi-hostpathplugin/templates/CSI_SNAPSHOTTER-rbac.yaml
+++ b/charts/csi-hostpathplugin/templates/CSI_SNAPSHOTTER-rbac.yaml
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-snapshotter
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-snapshotter-runner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotcontents
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotcontents/status
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - groupsnapshot.storage.k8s.io
+    resources:
+      - volumegroupsnapshotclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - groupsnapshot.storage.k8s.io
+    resources:
+      - volumegroupsnapshotcontents
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - groupsnapshot.storage.k8s.io
+    resources:
+      - volumegroupsnapshotcontents/status
+    verbs:
+      - update
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshotter-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshotter
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-snapshotter-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: external-snapshotter-leaderelection
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-snapshotter-leaderelection
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshotter
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: external-snapshotter-leaderelection
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/csi-hostpathplugin/templates/csi-groupsnapshotclass-v1beta1.yaml
+++ b/charts/csi-hostpathplugin/templates/csi-groupsnapshotclass-v1beta1.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.volumeGroupSnapshotClass.create -}}
+apiVersion: groupsnapshot.storage.k8s.io/v1beta1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: {{ .Values.volumeGroupSnapshotClass.name }}
+deletionPolicy: Delete
+driver: hostpath.csi.k8s.io
+{{- end -}}

--- a/charts/csi-hostpathplugin/templates/csi-hostpath-driverinfo.yaml
+++ b/charts/csi-hostpathplugin/templates/csi-hostpath-driverinfo.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: hostpath.csi.k8s.io
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: hostpath.csi.k8s.io
+    app.kubernetes.io/component: csi-driver
+spec:
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral
+  podInfoOnMount: true
+  fsGroupPolicy: File

--- a/charts/csi-hostpathplugin/templates/csi-hostpath-plugin.yaml
+++ b/charts/csi-hostpathplugin/templates/csi-hostpath-plugin.yaml
@@ -1,0 +1,390 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: csi-hostpathplugin-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: serviceaccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: attacher-cluster-role
+  name: csi-hostpathplugin-attacher-cluster-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-attacher-runner
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: health-monitor-controller-cluster-role
+  name: csi-hostpathplugin-health-monitor-controller-cluster-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-health-monitor-controller-runner
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: provisioner-cluster-role
+  name: csi-hostpathplugin-provisioner-cluster-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-provisioner-runner
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: resizer-cluster-role
+  name: csi-hostpathplugin-resizer-cluster-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-resizer-runner
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: snapshotter-cluster-role
+  name: csi-hostpathplugin-snapshotter-cluster-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-snapshotter-runner
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: snapshot-metadata-cluster-role
+  name: csi-hostpathplugin-snapshot-metadata-cluster-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-snapshot-metadata-runner
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: attacher-role
+  name: csi-hostpathplugin-attacher-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-attacher-cfg
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: health-monitor-controller-role
+  name: csi-hostpathplugin-health-monitor-controller-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-health-monitor-controller-cfg
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: provisioner-role
+  name: csi-hostpathplugin-provisioner-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-provisioner-cfg
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: resizer-role
+  name: csi-hostpathplugin-resizer-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-resizer-cfg
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: snapshotter-role
+  name: csi-hostpathplugin-snapshotter-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-snapshotter-leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-hostpathplugin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: plugin
+spec:
+  serviceName: csi-hostpathplugin
+  replicas: {{ .Values.csiHostpathplugin.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: hostpath.csi.k8s.io
+      app.kubernetes.io/part-of: csi-driver-host-path
+      app.kubernetes.io/name: csi-hostpathplugin
+      app.kubernetes.io/component: plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: hostpath.csi.k8s.io
+        app.kubernetes.io/part-of: csi-driver-host-path
+        app.kubernetes.io/name: csi-hostpathplugin
+        app.kubernetes.io/component: plugin
+    spec:
+      serviceAccountName: csi-hostpathplugin-sa
+      containers:
+        - name: hostpath
+          image: {{ .Values.csiHostpathplugin.hostpath.image.repository }}:{{ .Values.csiHostpathplugin.hostpath.image.tag }}
+          args:
+            - --drivername=hostpath.csi.k8s.io
+            - --v=5
+            - --endpoint=$(CSI_ENDPOINT)
+            - --nodeid=$(KUBE_NODE_NAME)
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 9898
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /var/lib/kubelet/plugins
+              mountPropagation: Bidirectional
+              name: plugins-dir
+            - mountPath: /csi-data-dir
+              name: csi-data-dir
+            - mountPath: /dev
+              name: dev-dir
+          imagePullPolicy: {{ .Values.csiHostpathplugin.hostpath.image.pullPolicy }}
+        - name: csi-external-health-monitor-controller
+          image: {{ .Values.csiHostpathplugin.csiExternalHealthMonitorController.image.repository }}:{{ .Values.csiHostpathplugin.csiExternalHealthMonitorController.image.tag }}
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: {{ .Values.csiHostpathplugin.csiExternalHealthMonitorController.image.pullPolicy }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: node-driver-registrar
+          image: {{ .Values.csiHostpathplugin.nodeDriverRegistrar.image.repository }}:{{ .Values.csiHostpathplugin.nodeDriverRegistrar.image.tag }}
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
+          securityContext:
+            privileged: true
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /registration
+              name: registration-dir
+            - mountPath: /csi-data-dir
+              name: csi-data-dir
+          imagePullPolicy: {{ .Values.csiHostpathplugin.nodeDriverRegistrar.image.pullPolicy }}
+        - name: liveness-probe
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          image: {{ .Values.csiHostpathplugin.livenessProbe.image.repository }}:{{ .Values.csiHostpathplugin.livenessProbe.image.tag }}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9898
+          imagePullPolicy: {{ .Values.csiHostpathplugin.livenessProbe.image.pullPolicy }}
+        - name: csi-attacher
+          image: {{ .Values.csiHostpathplugin.csiAttacher.image.repository }}:{{ .Values.csiHostpathplugin.csiAttacher.image.tag }}
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          imagePullPolicy: {{ .Values.csiHostpathplugin.csiAttacher.image.pullPolicy }}
+        - name: csi-provisioner
+          image: {{ .Values.csiHostpathplugin.csiProvisioner.image.repository }}:{{ .Values.csiHostpathplugin.csiProvisioner.image.tag }}
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+            - --feature-gates=Topology=true
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          imagePullPolicy: {{ .Values.csiHostpathplugin.csiProvisioner.image.pullPolicy }}
+        - name: csi-resizer
+          image: {{ .Values.csiHostpathplugin.csiResizer.image.repository }}:{{ .Values.csiHostpathplugin.csiResizer.image.tag }}
+          args:
+            - -v=5
+            - -csi-address=/csi/csi.sock
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          imagePullPolicy: {{ .Values.csiHostpathplugin.csiResizer.image.pullPolicy }}
+        - name: csi-snapshotter
+          image: {{ .Values.csiHostpathplugin.csiSnapshotter.image.repository }}:{{ .Values.csiHostpathplugin.csiSnapshotter.image.tag }}
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          imagePullPolicy: {{ .Values.csiHostpathplugin.csiSnapshotter.image.pullPolicy }}
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins
+            type: Directory
+          name: plugins-dir
+        - hostPath:
+            path: {{ .Values.csiHostpathplugin.volumes.csiDataDir.path }}
+            type: DirectoryOrCreate
+          name: csi-data-dir
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev-dir

--- a/charts/csi-hostpathplugin/templates/csi-storageclass.yaml
+++ b/charts/csi-hostpathplugin/templates/csi-storageclass.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.storageClass.create -}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageClass.name }}
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+{{- end -}}

--- a/charts/csi-hostpathplugin/templates/csi-volumesnapshotclass.yaml
+++ b/charts/csi-hostpathplugin/templates/csi-volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.volumeSnapshotClass.create -}}
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: {{ .Values.volumeSnapshotClass.name }}
+deletionPolicy: Delete
+driver: hostpath.csi.k8s.io
+{{- end -}}

--- a/charts/csi-hostpathplugin/values.yaml
+++ b/charts/csi-hostpathplugin/values.yaml
@@ -1,0 +1,55 @@
+---
+csiHostpathplugin:
+  replicaCount: 1
+  hostpath:
+    image:
+      repository: registry.k8s.io/sig-storage/hostpathplugin
+      pullPolicy: IfNotPresent
+      tag: v1.17.1
+  csiExternalHealthMonitorController:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-external-health-monitor-controller
+      pullPolicy: IfNotPresent
+      tag: v0.14.0
+  nodeDriverRegistrar:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+      pullPolicy: IfNotPresent
+      tag: v2.13.0
+  livenessProbe:
+    image:
+      repository: registry.k8s.io/sig-storage/livenessprobe
+      pullPolicy: IfNotPresent
+      tag: v2.15.0
+  csiAttacher:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-attacher
+      pullPolicy: IfNotPresent
+      tag: v4.8.0
+  csiProvisioner:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-provisioner
+      pullPolicy: IfNotPresent
+      tag: v5.2.0
+  csiResizer:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-resizer
+      pullPolicy: IfNotPresent
+      tag: v1.13.1
+  csiSnapshotter:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-snapshotter
+      pullPolicy: IfNotPresent
+      tag: v8.2.0
+  volumes:
+    csiDataDir:
+      path: /var/lib/csi-hostpath-data
+storageClass:
+  create: false
+  name: csi-hostpath-sc
+volumeSnapshotClass:
+  create: false
+  name: csi-hostpath-snapclass
+volumeGroupSnapshotClass:
+  create: false
+  name: csi-hostpath-groupsnapclass

--- a/deploy/kubernetes-1.30/chart-releaser.sh
+++ b/deploy/kubernetes-1.30/chart-releaser.sh
@@ -1,0 +1,1 @@
+../util/chart-releaser.sh

--- a/deploy/util/chart-releaser.sh
+++ b/deploy/util/chart-releaser.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script captures the steps required to successfully
+# deploy the hostpath plugin driver.  This should be considered
+# authoritative and all updates for this process should be
+# done here and referenced elsewhere.
+
+# The script assumes that kubectl is available on the OS path
+# where it is executed.
+
+set -euxo pipefail
+
+BASE_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+TEMP_DIR="$( mktemp -d )"
+
+# KUBELET_DATA_DIR can be set to replace the default /var/lib/kubelet.
+# All nodes must use the same directory.
+default_kubelet_data_dir=/var/lib/kubelet
+: ${KUBELET_DATA_DIR:=${default_kubelet_data_dir}}
+
+# If set, the following env variables override image registry and/or tag for each of the images.
+# They are named after the image name, with hyphen replaced by underscore and in upper case.
+#
+# - CSI_ATTACHER_REGISTRY
+# - CSI_ATTACHER_TAG
+# - CSI_NODE_DRIVER_REGISTRAR_REGISTRY
+# - CSI_NODE_DRIVER_REGISTRAR_TAG
+# - CSI_PROVISIONER_REGISTRY
+# - CSI_PROVISIONER_TAG
+# - CSI_SNAPSHOTTER_REGISTRY
+# - CSI_SNAPSHOTTER_TAG
+# - CSI_SNAPSHOT_METADATA_REGISTRY
+# - CSI_SNAPSHOT_METADATA_TAG
+# - HOSTPATHPLUGIN_REGISTRY
+# - HOSTPATHPLUGIN_TAG
+#
+# Alternatively, it is possible to override all registries or tags with:
+# - IMAGE_REGISTRY
+# - IMAGE_TAG
+# These are used as fallback when the more specific variables are unset or empty.
+#
+# IMAGE_TAG=canary is ignored for images that are blacklisted in the
+# deployment's optional canary-blacklist.txt file. This is meant for
+# images which have known API breakages and thus cannot work in those
+# deployments anymore. That text file must have the name of the blacklisted
+# image on a line by itself, other lines are ignored. Example:
+#
+#     # The following canary images are known to be incompatible with this
+#     # deployment:
+#     csi-snapshotter
+#
+# Beware that the .yaml files do not have "imagePullPolicy: Always". That means that
+# also the "canary" images will only be pulled once. This is good for testing
+# (starting a pod multiple times will always run with the same canary image), but
+# implies that refreshing that image has to be done manually.
+#
+# As a special case, 'none' as registry removes the registry name.
+# Set VOLUME_MODE_CONVERSION_TESTS to "true" to enable the feature in external-provisioner.
+
+# The default is to use the RBAC rules that match the image that is
+# being used, also in the case that the image gets overridden. This
+# way if there are breaking changes in the RBAC rules, the deployment
+# will continue to work.
+#
+# However, such breaking changes should be rare and only occur when updating
+# to a new major version of a sidecar. Nonetheless, to allow testing the scenario
+# where the image gets overridden but not the RBAC rules, updating the RBAC
+# rules can be disabled.
+: ${UPDATE_RBAC_RULES:=true}
+function rbac_version () {
+    yaml="$1"
+    image="$2"
+    update_rbac="$3"
+
+    if ! [ -f "$yaml" ]; then
+        # Fall back to csi-hostpath-plugin.yaml for those deployments which do not
+        # have individual pods for the sidecars.
+        yaml="$(dirname "$yaml")/csi-hostpath-plugin.yaml"
+    fi
+
+    # get version from `image: quay.io/k8scsi/csi-attacher:v1.0.1`, ignoring comments
+    version="$(sed -e 's/ *#.*$//' "$yaml" | grep "image:.*$image" | sed -e 's/ *#.*//' -e 's/.*://')"
+
+    if $update_rbac; then
+        # apply overrides
+        varname=$(echo $image | tr - _ | tr a-z A-Z)
+        eval version=\${${varname}_TAG:-\${IMAGE_TAG:-\$version}}
+    fi
+
+    # When using canary images, we have to assume that the
+    # canary images were built from the corresponding branch.
+    case "$version" in canary) version=master;;
+                        *-canary) version="$(echo "$version" | sed -e 's/\(.*\)-canary/release-\1/')";;
+    esac
+
+    echo "$version"
+}
+
+# version_gt returns true if arg1 is greater than arg2.
+#
+# This function expects versions to be one of the following formats:
+#   X.Y.Z, release-X.Y.Z, vX.Y.Z
+#
+#   where X,Y, and Z are any number.
+#
+# Partial versions (1.2, release-1.2) work as well.
+# The follow substrings are stripped before version comparison:
+#   - "v"
+#   - "release-"
+#
+# Usage:
+# version_gt release-1.3 v1.2.0  (returns true)
+# version_gt v1.1.1 v1.2.0  (returns false)
+# version_gt 1.1.1 v1.2.0  (returns false)
+# version_gt 1.3.1 v1.2.0  (returns true)
+# version_gt 1.1.1 release-1.2.0  (returns false)
+# version_gt 1.2.0 1.2.2  (returns false)
+function version_gt() {
+    versions=$(for ver in "$@"; do ver=${ver#release-}; ver=${ver#kubernetes-}; echo ${ver#v}; done)
+    greaterVersion=${1#"release-"};
+    greaterVersion=${greaterVersion#"kubernetes-"};
+    greaterVersion=${greaterVersion#"v"};
+    test "$(printf '%s' "$versions" | sort -V | head -n 1)" != "$greaterVersion"
+}
+
+function volume_mode_conversion () {
+    [ "${VOLUME_MODE_CONVERSION_TESTS}" == "true" ]
+}
+
+function snapshot_metadata () {
+    [ "${SNAPSHOT_METADATA_TESTS}" == "true" ]
+}
+
+# In addition, the RBAC rules can be overridden separately.
+# For snapshotter 2.0+, the directory has changed.
+SNAPSHOTTER_RBAC_RELATIVE_PATH="rbac.yaml"
+if version_gt $(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-snapshotter.yaml" csi-snapshotter "${UPDATE_RBAC_RULES}") "v1.255.255"; then
+	SNAPSHOTTER_RBAC_RELATIVE_PATH="csi-snapshotter/rbac-csi-snapshotter.yaml"
+fi
+SNAPSHOT_METADATA_RBAC_RELATIVE_PATH="snapshot-metadata-cluster-role.yaml"
+SNAPSHOT_METADATA_SIDECAR_PATCH_RELATIVE_PATH="${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch"
+
+CSI_PROVISIONER_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-provisioner.yaml" csi-provisioner false)/deploy/kubernetes/rbac.yaml"
+: ${CSI_PROVISIONER_RBAC:=https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-provisioner.yaml" csi-provisioner "${UPDATE_RBAC_RULES}")/deploy/kubernetes/rbac.yaml}
+CSI_ATTACHER_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-attacher/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-attacher.yaml" csi-attacher false)/deploy/kubernetes/rbac.yaml"
+: ${CSI_ATTACHER_RBAC:=https://raw.githubusercontent.com/kubernetes-csi/external-attacher/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-attacher.yaml" csi-attacher "${UPDATE_RBAC_RULES}")/deploy/kubernetes/rbac.yaml}
+CSI_SNAPSHOTTER_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-snapshotter.yaml" csi-snapshotter false)/deploy/kubernetes/${SNAPSHOTTER_RBAC_RELATIVE_PATH}"
+: ${CSI_SNAPSHOTTER_RBAC:=https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-snapshotter.yaml" csi-snapshotter "${UPDATE_RBAC_RULES}")/deploy/kubernetes/${SNAPSHOTTER_RBAC_RELATIVE_PATH}}
+CSI_SNAPSHOT_METADATA_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/$(rbac_version "${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata false)/deploy/${SNAPSHOT_METADATA_RBAC_RELATIVE_PATH}"
+: ${CSI_SNAPSHOT_METADATA_RBAC:=https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/$(rbac_version "${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata "${UPDATE_RBAC_RULES}")/deploy/${SNAPSHOT_METADATA_RBAC_RELATIVE_PATH}}
+CSI_RESIZER_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-resizer/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-resizer.yaml" csi-resizer false)/deploy/kubernetes/rbac.yaml"
+: ${CSI_RESIZER_RBAC:=https://raw.githubusercontent.com/kubernetes-csi/external-resizer/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-resizer.yaml" csi-resizer "${UPDATE_RBAC_RULES}")/deploy/kubernetes/rbac.yaml}
+
+CSI_EXTERNALHEALTH_MONITOR_RBAC_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-plugin.yaml" csi-external-health-monitor-controller false)/deploy/kubernetes/external-health-monitor-controller/rbac.yaml"
+: ${CSI_EXTERNALHEALTH_MONITOR_RBAC:=https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/$(rbac_version "${BASE_DIR}/hostpath/csi-hostpath-plugin.yaml" csi-external-health-monitor-controller "${UPDATE_RBAC_RULES}")/deploy/kubernetes/external-health-monitor-controller/rbac.yaml}
+
+CSI_SNAPSHOT_METADATA_TLS_CERT_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/$(rbac_version "${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata false)/deploy/example/csi-driver/testdata/csi-snapshot-metadata-tls-secret.yaml"
+SNAPSHOT_METADATA_SERVICE_CR_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/$(rbac_version "${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata false)/deploy/example/csi-driver/testdata/snapshotmetadataservice.yaml"
+CSI_SNAPSHOT_METADATA_SERVICE_YAML="https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/$(rbac_version "${BASE_DIR}/hostpath/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata false)/deploy/example/csi-driver/testdata/csi-snapshot-metadata-service.yaml"
+
+INSTALL_CRD=${INSTALL_CRD:-"false"}
+VOLUME_MODE_CONVERSION_TESTS=${VOLUME_MODE_CONVERSION_TESTS:-"false"}
+SNAPSHOT_METADATA_TESTS=${SNAPSHOT_METADATA_TESTS:-"false"}
+
+# Some images are not affected by *_REGISTRY/*_TAG and IMAGE_* variables.
+# The default is to update unless explicitly excluded.
+update_image () {
+    case "$1" in socat) return 1;; esac
+}
+
+run () {
+    echo "$@" >&2
+    "$@"
+}
+
+CSI_HOSTPATHPLUGIN_TEMPLATES=${BASE_DIR}/../../charts/csi-hostpathplugin/templates
+CSI_HOSTPATHPLUGIN_YAML=${CSI_HOSTPATHPLUGIN_TEMPLATES}/csi-hostpath-plugin.yaml
+CSI_STORAGECLASS_YAML=${CSI_HOSTPATHPLUGIN_TEMPLATES}/csi-storageclass.yaml
+CSI_VOLUMESNAPSHOTCLASS_YAML=${CSI_HOSTPATHPLUGIN_TEMPLATES}/csi-volumesnapshotclass.yaml
+CSI_GROUPSNAPSHOTCLASS_YAML=${CSI_HOSTPATHPLUGIN_TEMPLATES}/csi-groupsnapshotclass-v1beta1.yaml
+
+# rbac rules
+echo "applying RBAC rules"
+components=(CSI_PROVISIONER CSI_ATTACHER CSI_SNAPSHOTTER CSI_RESIZER CSI_EXTERNALHEALTH_MONITOR)
+if snapshot_metadata; then
+    components+=(CSI_SNAPSHOT_METADATA)
+fi
+for component in "${components[@]}"; do
+    eval current="\${${component}_RBAC}"
+    eval original="\${${component}_RBAC_YAML}"
+    if [ "$current" != "$original" ]; then
+        echo "Using non-default RBAC rules for $component. Changes from $original to $current are:"
+        diff -c <(wget --quiet -O - "$original") <(if [[ "$current" =~ ^http ]]; then wget --quiet -O - "$current"; else cat "$current"; fi) || true
+    fi
+
+    # using kustomize kubectl plugin to add labels to he rbac files.
+    # since we are deploying rbas directly with the url, the kustomize plugin only works with the local files
+    # we need to add the files locally in temp folder and using kustomize adding labels it will be applied
+    if [[ "${current}" =~ ^http:// ]] || [[ "${current}" =~ ^https:// ]]; then
+      run curl "${current}" --output "${TEMP_DIR}"/rbac.yaml --silent --location
+    else
+        # Even for local files we need to copy because kustomize only supports files inside
+        # the root of a kustomization.
+        cp "${current}" "${TEMP_DIR}"/rbac.yaml
+    fi
+
+    cat <<- EOF > "${TEMP_DIR}"/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app.kubernetes.io/instance: hostpath.csi.k8s.io
+  app.kubernetes.io/part-of: csi-driver-host-path
+
+resources:
+- ./rbac.yaml
+EOF
+
+    cp -rfp ${TEMP_DIR}/rbac.yaml ${CSI_HOSTPATHPLUGIN_TEMPLATES}/$component-rbac.yaml
+done
+
+# deploy hostpath plugin and registrar sidecar
+echo "deploying hostpath components"
+for i in $(ls ${BASE_DIR}/hostpath/csi-hostpath-driverinfo.yaml ${BASE_DIR}/hostpath/csi-hostpath-plugin.yaml | sort); do
+    echo "   $i"
+    if volume_mode_conversion; then
+      sed -i -e 's/# end csi-provisioner args/- \"--prevent-volume-mode-conversion=true\"\n            # end csi-provisioner args/' $i
+    fi
+
+    # Add external-snapshot-metadata sidecar to the driver, mount TLS certs,
+    # and enable snapshot-metadata service
+    if snapshot_metadata; then
+      sed -i -e "/# end csi containers/r ${SNAPSHOT_METADATA_SIDECAR_PATCH_RELATIVE_PATH}" $i
+      sed -i -e 's/# end csi volumes/- name: csi-snapshot-metadata-server-certs\n          secret:\n            secretName: csi-snapshot-metadata-certs\n        # end csi volumes/' $i
+      sed -i -e 's/# end hostpath args/- \"--enable-snapshot-metadata\"\n            # end hostpath args/' $i
+    fi
+    modified="$(cat "$i" | sed -e "s;${default_kubelet_data_dir}/;${KUBELET_DATA_DIR}/;" | while IFS= read -r line; do
+        nocomments="$(echo "$line" | sed -e 's/ *#.*$//')"
+        if echo "$nocomments" | grep -q '^[[:space:]]*image:[[:space:]]*'; then
+            # Split 'image: quay.io/k8scsi/csi-attacher:v1.0.1'
+            # into image (quay.io/k8scsi/csi-attacher:v1.0.1),
+            # registry (quay.io/k8scsi),
+            # name (csi-attacher),
+            # tag (v1.0.1).
+            image=$(echo "$nocomments" | sed -e 's;.*image:[[:space:]]*;;')
+            registry=$(echo "$image" | sed -e 's;\(.*\)/.*;\1;')
+            name=$(echo "$image" | sed -e 's;.*/\([^:]*\).*;\1;')
+            tag=$(echo "$image" | sed -e 's;.*:;;')
+
+            # Variables are with underscores and upper case.
+            varname=$(echo $name | tr - _ | tr a-z A-Z)
+
+            # Now replace registry and/or tag, if set as env variables.
+            # If not set, the replacement is the same as the original value.
+            # Only do this for the images which are meant to be configurable.
+            if update_image "$name"; then
+                prefix=$(eval echo \${${varname}_REGISTRY:-${IMAGE_REGISTRY:-${registry}}}/ | sed -e 's;none/;;')
+                suffix=$(eval echo :\${${varname}_TAG:-${IMAGE_TAG:-${tag}}})
+                line="$(echo "$nocomments" | sed -e "s;$image;${prefix}${name}${suffix};")"
+            fi
+            echo "        using $line" >&2
+        fi
+        echo "$line"
+    done)"
+    echo "$modified" > ${CSI_HOSTPATHPLUGIN_TEMPLATES}/$(basename $i)
+done
+
+cp -rfp examples/*class*.yaml ${CSI_HOSTPATHPLUGIN_TEMPLATES}/
+
+# Convert csi-hostpathplugin as Heal Charts.
+find ${CSI_HOSTPATHPLUGIN_TEMPLATES} -type f -name '*.yaml' | while read -r _YAML
+do
+    yq -i -P -I 2 '... comments=""' $_YAML
+    yq -i e '(select(.metadata | has("namespace")) | .metadata.namespace) = "{{ .Release.Namespace }}"' $_YAML
+    yq -i e '(select(.subjects.[] | has("namespace")) | .subjects.[].namespace) = "{{ .Release.Namespace }}"' $_YAML
+done
+
+yq -i e '(select(.spec | has("replicas")) | .spec.replicas) = "{{ .Values.csiHostpathplugin.replicaCount }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "hostpath") | .image) = "{{ .Values.csiHostpathplugin.hostpath.image.repository }}:{{ .Values.csiHostpathplugin.hostpath.image.tag }}"' $CSI_HOSTPATHPLUGIN_YAML
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "hostpath") | .imagePullPolicy) = "{{ .Values.csiHostpathplugin.hostpath.image.pullPolicy }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-external-health-monitor-controller") | .image) = "{{ .Values.csiHostpathplugin.csiExternalHealthMonitorController.image.repository }}:{{ .Values.csiHostpathplugin.csiExternalHealthMonitorController.image.tag }}"' $CSI_HOSTPATHPLUGIN_YAML
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-external-health-monitor-controller") | .imagePullPolicy) = "{{ .Values.csiHostpathplugin.csiExternalHealthMonitorController.image.pullPolicy }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "node-driver-registrar") | .image) = "{{ .Values.csiHostpathplugin.nodeDriverRegistrar.image.repository }}:{{ .Values.csiHostpathplugin.nodeDriverRegistrar.image.tag }}"' $CSI_HOSTPATHPLUGIN_YAML
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "node-driver-registrar") | .imagePullPolicy) = "{{ .Values.csiHostpathplugin.nodeDriverRegistrar.image.pullPolicy }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "liveness-probe") | .image) = "{{ .Values.csiHostpathplugin.livenessProbe.image.repository }}:{{ .Values.csiHostpathplugin.livenessProbe.image.tag }}"' $CSI_HOSTPATHPLUGIN_YAML
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "liveness-probe") | .imagePullPolicy) = "{{ .Values.csiHostpathplugin.livenessProbe.image.pullPolicy }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-attacher") | .image) = "{{ .Values.csiHostpathplugin.csiAttacher.image.repository }}:{{ .Values.csiHostpathplugin.csiAttacher.image.tag }}"' $CSI_HOSTPATHPLUGIN_YAML
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-attacher") | .imagePullPolicy) = "{{ .Values.csiHostpathplugin.csiAttacher.image.pullPolicy }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-provisioner") | .image) = "{{ .Values.csiHostpathplugin.csiProvisioner.image.repository }}:{{ .Values.csiHostpathplugin.csiProvisioner.image.tag }}"' $CSI_HOSTPATHPLUGIN_YAML
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-provisioner") | .imagePullPolicy) = "{{ .Values.csiHostpathplugin.csiProvisioner.image.pullPolicy }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-resizer") | .image) = "{{ .Values.csiHostpathplugin.csiResizer.image.repository }}:{{ .Values.csiHostpathplugin.csiResizer.image.tag }}"' $CSI_HOSTPATHPLUGIN_YAML
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-resizer") | .imagePullPolicy) = "{{ .Values.csiHostpathplugin.csiResizer.image.pullPolicy }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-snapshotter") | .image) = "{{ .Values.csiHostpathplugin.csiSnapshotter.image.repository }}:{{ .Values.csiHostpathplugin.csiSnapshotter.image.tag }}"' $CSI_HOSTPATHPLUGIN_YAML
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.containers.[] | select(.name == "csi-snapshotter") | .imagePullPolicy) = "{{ .Values.csiHostpathplugin.csiSnapshotter.image.pullPolicy }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.spec | has("template")) | .spec.template.spec.volumes.[] | select(.name == "csi-data-dir") | .hostPath.path) = "{{ .Values.csiHostpathplugin.volumes.csiDataDir.path }}"' $CSI_HOSTPATHPLUGIN_YAML
+
+yq -i e '(select(.metadata | has("name")) | .metadata.name) = "{{ .Values.storageClass.name }}"' $CSI_STORAGECLASS_YAML
+sed -i '1s/^/{{- if .Values.storageClass.create -}}\n/g' $CSI_STORAGECLASS_YAML
+sed -i '$s/$/\n{{- end -}}/g' $CSI_STORAGECLASS_YAML
+
+yq -i e '(select(.metadata | has("name")) | .metadata.name) = "{{ .Values.volumeSnapshotClass.name }}"' $CSI_VOLUMESNAPSHOTCLASS_YAML
+sed -i '1s/^/{{- if .Values.volumeSnapshotClass.create -}}\n/g' $CSI_VOLUMESNAPSHOTCLASS_YAML
+sed -i '$s/$/\n{{- end -}}/g' $CSI_VOLUMESNAPSHOTCLASS_YAML
+
+yq -i e '(select(.metadata | has("name")) | .metadata.name) = "{{ .Values.volumeGroupSnapshotClass.name }}"' $CSI_GROUPSNAPSHOTCLASS_YAML
+sed -i '1s/^/{{- if .Values.volumeGroupSnapshotClass.create -}}\n/g' $CSI_GROUPSNAPSHOTCLASS_YAML
+sed -i '$s/$/\n{{- end -}}/g' $CSI_GROUPSNAPSHOTCLASS_YAML
+
+find ${CSI_HOSTPATHPLUGIN_TEMPLATES} -type f -name '*.yaml' | xargs sed -i "s/'{{/{{/g;s/}}'/}}/g"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR convert our static deployment manifests from `deploy/kubernetes-latest/*` into Helm Charts under `charts/*`, by running a convert script under `deploy/util/chart-releaser.sh`.

Moreover, it handle the chart release with branch `gh-pages`, by integrate with https://github.com/helm/chart-releaser-action.

The sample helm repo could find from https://alvistack.github.io/kubernetes-csi-csi-driver-host-path/index.yaml, by:

    helm repo add csi-driver-host-path https://alvistack.github.io/kubernetes-csi-csi-driver-host-path/
    helm repo update
    helm search repo csi-driver-host-path

Before each stable tag release, maintainers only required to:
1. Run the `./deploy/kubernetes-latest/chart-releaser.sh` and update templates under `charts/*/templates/*`
2. Double confirm `charts/*/values.yml` with correct values, e.g. image tags
3. `git add --all --force charts/* && git commit`

```release-note
Create Helm Chart from Static Manifests
```
