### PR TITLE
Add --enable-list-snapshots command-line option

### DIFF
--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -62,6 +62,7 @@ func main() {
 	flag.Var(&cfg.AcceptedMutableParameterNames, "accepted-mutable-parameter-names", "Comma separated list of parameter names that can be modified on a persistent volume. This is only used when enable-controller-modify-volume is true. If unset, all parameters are mutable.")
 	flag.BoolVar(&cfg.DisableControllerExpansion, "disable-controller-expansion", false, "Disables Controller volume expansion capability.")
 	flag.BoolVar(&cfg.DisableNodeExpansion, "disable-node-expansion", false, "Disables Node volume expansion capability.")
+	flag.BoolVar(&cfg.EnableListSnapshots, "enable-list-snapshots", true, "Enables ControllerServiceCapability_RPC_LIST_SNAPSHOTS capability. Defaults to true.")
 	flag.Int64Var(&cfg.MaxVolumeExpansionSizeNode, "max-volume-size-node", 0, "Maximum allowed size of volume when expanded on the node. Defaults to same size as max-volume-size.")
 
 	flag.Int64Var(&cfg.AttachLimit, "attach-limit", 0, "Maximum number of attachable volumes on a node. Zero refers to no limit.")

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -877,7 +877,6 @@ func (hp *hostPath) getControllerServiceCapabilities() []*csi.ControllerServiceC
 			csi.ControllerServiceCapability_RPC_GET_VOLUME,
 			csi.ControllerServiceCapability_RPC_GET_CAPACITY,
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
-			csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 			csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
@@ -891,6 +890,9 @@ func (hp *hostPath) getControllerServiceCapabilities() []*csi.ControllerServiceC
 		}
 		if hp.config.EnableControllerModifyVolume {
 			cl = append(cl, csi.ControllerServiceCapability_RPC_MODIFY_VOLUME)
+		}
+		if hp.config.EnableListSnapshots {
+			cl = append(cl, csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS)
 		}
 	}
 

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -88,6 +88,7 @@ type Config struct {
 	DisableNodeExpansion          bool
 	MaxVolumeExpansionSizeNode    int64
 	CheckVolumeLifecycle          bool
+	EnableListSnapshots           bool
 }
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

This commit introduces the --enable-list-snapshots command-line option, allowing users to explicitly enable or disable the ControllerServiceCapability_RPC_LIST_SNAPSHOTS capability.

By default, this option is set to true to preserve existing behavior.

Disabling RPC_LIST_SNAPSHOTS is useful for emulating the behavior of CSI drivers that do not support this optional RPC call.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce support for the `--enable-list-snapshots=<bool>` command line option, allowing users to explicitly enable or disable the ControllerServiceCapability_RPC_LIST_SNAPSHOTS capability. By default, this option is set to true to preserve existing behavior.
```
