### PR TITLE
Add ControllerServer.GetSnapshot CSI procedure

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -25,6 +25,8 @@ CSI_PROW_GINKO_PARALLEL="-p -nodes 40" # default was 7
 CSI_PROW_HOSTPATH_DRIVER_NAME="hostpath.csi.k8s.io"
 
 CSI_PROW_TESTS_SANITY="sanity"
+# TODO(nixpanic): remove when csi-release-tools PR#314 is merged
+CSI_PROW_SANITY_VERSION="v5.5.0"
 
 # We need to hardcode e2e version for resizer for now, because
 # we need fixes from latest release-1.31 branch for all e2es to pass.

--- a/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-attacher.yaml
+++ b/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-attacher.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-plugin.yaml
@@ -77,13 +77,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-external-health-monitor-controller
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.14.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -97,7 +97,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-provisioner.yaml
+++ b/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-provisioner.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.3.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-resizer.yaml
+++ b/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-resizer.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-snapshotter.yaml
+++ b/deploy/kubernetes-1.30-test/hostpath/csi-hostpath-snapshotter.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes-1.30/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.30/hostpath/csi-hostpath-plugin.yaml
@@ -281,7 +281,7 @@ spec:
               name: dev-dir
 
         - name: csi-external-health-monitor-controller
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.16.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -295,7 +295,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -336,13 +336,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -356,7 +356,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.3.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -372,7 +372,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v2.0.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
@@ -386,7 +386,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/hack/bump-image-versions.sh
+++ b/hack/bump-image-versions.sh
@@ -46,5 +46,5 @@ fi
 
 for image in $images; do
     latest=$(skopeo list-tags --retry-times 3 docker://registry.k8s.io/sig-storage/"$image" | jq -r '.Tags[]' | grep -e '^v.*$' | sort -V | tail -n 1)
-    find deploy -type f -exec sed -i '' "s;\(image: registry.k8s.io/sig-storage/$image:\).*;\1$latest;" {} \;
+    find deploy -type f -exec sed -i "s;\(image: registry.k8s.io/sig-storage/$image:\).*;\1$latest;" {} \;
 done

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -239,8 +239,8 @@ configvar CSI_PROW_SIDECAR_E2E_PATH "${CSI_PROW_SIDECAR_E2E_IMPORT_PATH}" "CSI S
 # csi.sock as a TCP service for use by the csi-sanity command, which runs outside
 # of the cluster. The alternative would have been to (cross-)compile csi-sanity
 # and install it inside the cluster, which is not necessarily easier.
-configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
-configvar CSI_PROW_SANITY_VERSION v5.3.1 "csi-test version"
+configvar CSI_PROW_SANITY_REPO https://github.com/nixpanic/csi-test "csi-test repo"
+configvar CSI_PROW_SANITY_VERSION GetSnapshot "csi-test version"
 configvar CSI_PROW_SANITY_PACKAGE_PATH github.com/kubernetes-csi/csi-test "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

The new `ControllerServer.GetSnapshot` CSI procedure has been added to the specification. This should be implemented in the csi-driver-hostpath so that other components can use it for testing.

**Which issue(s) this PR fixes**:

Depends-on: kubernetes-csi/csi-test#573 + new release
Depends-on: _release-tools PR with new csi-test release_

**Special notes for your reviewer**:

Marked as **Draft** because there is no CSI spec release with the new `GetSnapshot` procedure yet.

**Does this PR introduce a user-facing change?**:

```release-note
Add support for the new ControllerServer.GetSnapshot CSI procedure.
```
