### PR TITLE
Bump up hostpathplugin image tag to v1.16.1

### DIFF
--- a/deploy/kubernetes-1.30/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.30/hostpath/csi-hostpath-plugin.yaml
@@ -237,7 +237,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

This PR bumps up the image tag used in deployment manifests for hostpath-plugin image to latest release i.e `v1.16.1` 

```release-note
NONE
```
