### PR TITLE
gcr.io to registry.k8s

### DIFF
--- a/docs/example-snapshot-metadata.md
+++ b/docs/example-snapshot-metadata.md
@@ -137,7 +137,7 @@ If this is not the case then substitute the explicit use of `-n default` with th
     spec:
       restartPolicy: Always
       containers:
-        - image: gcr.io/google_containers/busybox
+        - image: registry.k8s/google_containers/busybox
           command: ["/bin/sh", "-c"]
           args: [ "tail -f /dev/null" ]
           name: busybox

--- a/examples/csi-pod-block.yaml
+++ b/examples/csi-pod-block.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   restartPolicy: Always
   containers:
-    - image: gcr.io/google_containers/busybox
+    - image: registry.k8s/google_containers/busybox
       command: ["/bin/sh", "-c"]
       args: [ "tail -f /dev/null" ]
       name: busybox

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36'
+  - name: 'registry.k8s/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -218,7 +218,7 @@ configvar CSI_PROW_DRIVER_CANARY "${CSI_PROW_HOSTPATH_CANARY}" "driver image ove
 
 # Image registry to use for canary images.
 # Only valid if CSI_PROW_DRIVER_CANARY == "canary".
-configvar CSI_PROW_DRIVER_CANARY_REGISTRY "gcr.io/k8s-staging-sig-storage" "registry for canary images"
+configvar CSI_PROW_DRIVER_CANARY_REGISTRY "registry.k8s/k8s-staging-sig-storage" "registry for canary images"
 
 # The E2E testing can come from an arbitrary repo. The expectation is that
 # the repo supports "go test ./test/e2e -args --storage.testdriver" (https://github.com/kubernetes/kubernetes/pull/72836)
@@ -960,7 +960,7 @@ patch_kubernetes () {
         # overrides that registry.
         find "$source/test/e2e/testing-manifests/storage-csi/mock" -name '*.yaml' -print0 | xargs -0 sed -i -e 's;registry.k8s.io/sig-storage/\(.*\):v.*;registry.k8s.io/sig-storage/\1:canary;'
         cat >"$target/e2e-repo-list" <<EOF
-sigStorageRegistry: gcr.io/k8s-staging-sig-storage
+sigStorageRegistry: registry.k8s/k8s-staging-sig-storage
 EOF
         cat >&2 <<EOF
 


### PR DESCRIPTION
This PR replaces usage of the legacy Google-owned `gcr.io/k8s-testimages` registry with the community-owned `registry.k8s.io/k8s-testimages`.

This change aligns with Kubernetes community guidelines to decouple from Google-owned infrastructure.

Ref: https://github.com/kubernetes-csi/csi-driver-host-path/issues/608