### PR TITLE
migrated from registry.k8s to gcr.io

### DIFF
--- a/examples/csi-pod-block.yaml
+++ b/examples/csi-pod-block.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   restartPolicy: Always
   containers:
-    - image: gcr.io/google_containers/busybox
+    - image: registry.k8s/google_containers/busybox
       command: ["/bin/sh", "-c"]
       args: [ "tail -f /dev/null" ]
       name: busybox

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36'
+  - name: 'registry.k8s/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}
@@ -40,7 +40,7 @@ substitutions:
   # _PULL_BASE_REF will contain the ref that was pushed to trigger this build -
   # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: 'master'
-  # The default gcr.io staging project for Kubernetes-CSI
+  # The default registry.k8s staging project for Kubernetes-CSI
   # (=> https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage/GLOBAL).
   # Might be overridden in the Prow build job for a repo which wants
   # images elsewhere.


### PR DESCRIPTION
This PR replaces usage of the legacy Google-owned `gcr.io/k8s-testimages` registry with the community-owned `registry.k8s.io/k8s-testimages`.

This change aligns with Kubernetes community guidelines to decouple from Google-owned infrastructure.

Ref: https://github.com/kubernetes-csi/csi-driver-host-path/issues/608 cc @xing-yang 