### PR TITLE
optimize findmnt usage to avoid JSON depth errors

### DIFF
--- a/pkg/hostpath/healthcheck.go
+++ b/pkg/hostpath/healthcheck.go
@@ -83,7 +83,7 @@ func checkMountPointExist(volumePath string) (bool, error) {
 		return false, fmt.Errorf("findmnt not found: %w", err)
 	}
 
-	out, err := exec.Command(cmdPath, "--json").CombinedOutput()
+	out, err := exec.Command(cmdPath, "--json", "--target", volumePath).CombinedOutput()
 	if err != nil {
 		klog.V(3).Infof("failed to execute command: %+v", cmdPath)
 		return false, err
@@ -98,29 +98,10 @@ func checkMountPointExist(volumePath string) (bool, error) {
 		return false, fmt.Errorf("failed to parse the mount infos: %+v", err)
 	}
 
-	mountInfosOfPod := MountPointInfo{}
 	for _, mountInfo := range mountInfos {
-		if mountInfo.Target == podVolumeTargetPath {
-			mountInfosOfPod = mountInfo
-			break
+		if mountInfo.Target == volumePath || strings.Contains(mountInfo.Source, volumePath) {
+			return true, nil
 		}
-	}
-
-	for _, mountInfo := range mountInfosOfPod.ContainerFileSystem {
-		if !strings.Contains(mountInfo.Source, volumePath) {
-			continue
-		}
-
-		_, err = os.Stat(mountInfo.Target)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return false, nil
-			}
-
-			return false, err
-		}
-
-		return true, nil
 	}
 
 	return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`findmnt --json` without arguments, has forced the OS to scan and return the entire mount tree of the host. 
On a busy Kubernetes node, this tree is extremely large and deep, causing the Go JSON decoder to hit its depth limits.

Go's JSON decoder has a default recursion limit (usually 10,000 levels). 
https://github.com/golang/go/blob/master/src/encoding/json/scanner.go#L146-L148
The host's mount tree exceeded this, causing the driver to error out with that `invalid character '{' exceeded max depth message` we saw in the logs.

This PR fixes the issue by explicitly passing the `--target` parameter. So that it only returns information related to that particular volume only. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
