### PR TITLE
csi: fix node-driver-registrar liveness probe to use --http-endpoint

### DIFF
--- a/deploy/kubernetes-1.30/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-1.30/hostpath/csi-hostpath-plugin.yaml
@@ -300,6 +300,7 @@ spec:
             - --v=5
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
+            - --http-endpoint=:9809
           securityContext:
             # This is necessary only for systems with SELinux, where
             # non-privileged sidecar containers cannot access unix domain socket
@@ -311,6 +312,18 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+          ports:
+            - containerPort: 9809
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -65,6 +65,7 @@ spec:
             - --v=5
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
+            - --http-endpoint=:9809
           securityContext:
             # This is necessary only for systems with SELinux, where
             # non-privileged sidecar containers cannot access unix domain socket
@@ -76,6 +77,18 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+          ports:
+            - containerPort: 9809
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
           volumeMounts:
           - mountPath: /csi
             name: socket-dir


### PR DESCRIPTION
Replace missing liveness probe on node-driver-registrar containers with an HTTP healthz probe enabled via --http-endpoint=:9809. Without this flag the built-in healthz server is never started and there is no effective health checking on the kubelet registration socket.

Affects deploy/kubernetes-1.30 and deploy/kubernetes-distributed manifests (kubernetes-latest and kubernetes-1.31 are symlinks to kubernetes-1.30). gce-pd-style httpGet probe pattern is used as reference.


> /kind cleanup

```release-note
NONE
```
