### PR TITLE
Fix inverted error check in DeleteSnapshot

### DIFF
--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -649,7 +649,12 @@ func (hp *hostPath) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotR
 	defer hp.mutex.Unlock()
 
 	// If the snapshot has a GroupSnapshotID, deletion is not allowed and should return InvalidArgument.
-	if snapshot, err := hp.state.GetSnapshotByID(snapshotID); err != nil && snapshot.GroupSnapshotID != "" {
+	snapshot, err := hp.state.GetSnapshotByID(snapshotID)
+	if err != nil {
+		if status.Code(err) != codes.NotFound {
+			return nil, err
+		}
+	} else if snapshot.GroupSnapshotID != "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Snapshot with ID %s is part of groupsnapshot %s", snapshotID, snapshot.GroupSnapshotID)
 	}
 

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -649,7 +649,7 @@ func (hp *hostPath) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotR
 	defer hp.mutex.Unlock()
 
 	// If the snapshot has a GroupSnapshotID, deletion is not allowed and should return InvalidArgument.
-	if snapshot, err := hp.state.GetSnapshotByID(snapshotID); err != nil && snapshot.GroupSnapshotID != "" {
+	if snapshot, err := hp.state.GetSnapshotByID(snapshotID); err == nil && snapshot.GroupSnapshotID != "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Snapshot with ID %s is part of groupsnapshot %s", snapshotID, snapshot.GroupSnapshotID)
 	}
 

--- a/pkg/hostpath/controllerserver_test.go
+++ b/pkg/hostpath/controllerserver_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-driver-host-path/pkg/state"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestCreateVolume(t *testing.T) {
@@ -170,6 +172,70 @@ func TestCreateVolume(t *testing.T) {
 				resp.Volume.VolumeId = ""
 			}
 			assert.Equal(t, tc.resp, resp)
+		})
+	}
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	testCases := []struct {
+		name      string
+		snapshots []state.Snapshot
+		reqID     string
+		wantCode  codes.Code
+	}{
+		{
+			name:     "delete non-existent snapshot succeeds",
+			reqID:    "non-existent",
+			wantCode: codes.OK,
+		},
+		{
+			name: "delete snapshot without group succeeds",
+			snapshots: []state.Snapshot{
+				{Id: "snap-1", Name: "snap-1-name"},
+			},
+			reqID:    "snap-1",
+			wantCode: codes.OK,
+		},
+		{
+			name: "delete snapshot belonging to group fails",
+			snapshots: []state.Snapshot{
+				{Id: "snap-2", Name: "snap-2-name", GroupSnapshotID: "group-1"},
+			},
+			reqID:    "snap-2",
+			wantCode: codes.InvalidArgument,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stateDir, err := os.MkdirTemp(os.TempDir(), "csi-data-dir")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(stateDir)
+
+			cfg := Config{
+				StateDir:   stateDir,
+				Endpoint:   "unix://tmp/csi.sock",
+				DriverName: "hostpath.csi.k8s.io",
+				NodeID:     "fakeNodeID",
+			}
+			hp, err := NewHostPathDriver(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, snap := range tc.snapshots {
+				if err := hp.state.UpdateSnapshot(snap); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			_, err = hp.DeleteSnapshot(context.TODO(), &csi.DeleteSnapshotRequest{
+				SnapshotId: tc.reqID,
+			})
+
+			gotCode := status.Code(err)
+			assert.Equal(t, tc.wantCode, gotCode, "unexpected status code: %v", err)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`GetSnapshotByID` returns `(Snapshot{}, NotFound)` when a snapshot is not found, so the original condition `err != nil && snapshot.GroupSnapshotID != ""` could never evaluate to true the zero-value `Snapshot` always has `GroupSnapshotID == ""`. The guard needs `err == nil` to inspect the fields of a successfully retrieved snapshot.

As a result, individual snapshots belonging to a `VolumeGroupSnapshot` could be deleted via `DeleteSnapshot`, breaking group snapshot consistency guarantees.

This PR also adds test coverage for `DeleteSnapshot`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```