### PR TITLE
deploy: update sidecar image versions

### DIFF
--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.3.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -60,7 +60,7 @@ spec:
               name: socket-dir
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -145,7 +145,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898


### PR DESCRIPTION
Update cross-referenced sidecar container images in `deploy/kubernetes-distributed/` to their latest stable releases.

## Changes

- `csi-provisioner`: v6.2.0 → v6.3.0
- `csi-node-driver-registrar`: v2.16.0 → v2.17.0
- `livenessprobe`: v2.18.0 → v2.19.0

`hostpathplugin` (v1.17.1) is already at its latest stable release and is unchanged.

Note: `deploy/kubernetes-1.30/` and `deploy/kubernetes-1.30-test/` are intentionally pinned to their Kubernetes release versions and are not modified.