### PR TITLE
deploy: update sidecar image versions

### DIFF
--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-plugin.yaml
@@ -98,7 +98,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.18.0
           args:
             - --drivername=hostpath.csi.k8s.io
             - --v=5

--- a/deploy/kubernetes-distributed/hostpath/csi-hostpath-testing.yaml
+++ b/deploy/kubernetes-distributed/hostpath/csi-hostpath-testing.yaml
@@ -64,7 +64,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.18.0
           command:
           - socat
           args:


### PR DESCRIPTION
Update the cross-referenced `hostpathplugin` sidecar image in `deploy/kubernetes-distributed/hostpath/` to its latest stable release.

## Changes

- `hostpathplugin`: v1.17.1 → v1.18.0 (`csi-hostpath-plugin.yaml` and `csi-hostpath-testing.yaml`)

`csi-provisioner` (v6.3.0), `csi-node-driver-registrar` (v2.17.0), and `livenessprobe` (v2.19.0) are already at their latest stable releases and are unchanged.

Note: `deploy/kubernetes-1.30/` and `deploy/kubernetes-1.30-test/` are intentionally pinned to their Kubernetes release versions and are not modified.